### PR TITLE
fix: vast deprecated /api/v0/instances/ list endpoint (410)

### DIFF
--- a/aiod/onboard.py
+++ b/aiod/onboard.py
@@ -67,7 +67,7 @@ def validate_vast_key(key: str, timeout: float = 15.0) -> tuple[bool, str]:
         return False, "no key provided"
     try:
         r = httpx.get(
-            "https://console.vast.ai/api/v0/instances/",
+            "https://console.vast.ai/api/v1/instances/",
             headers={"Authorization": f"Bearer {key}"},
             timeout=timeout,
         )
@@ -79,8 +79,13 @@ def validate_vast_key(key: str, timeout: float = 15.0) -> tuple[bool, str]:
             return True, f"valid (you have {n} instance(s))"
         except ValueError:
             return True, "valid"
-    if r.status_code == 401:
-        return False, "rejected (401) — wrong or revoked key"
+    # vast.ai signals a bad/revoked key with an auth_error body — and not always a
+    # 401 (a wrong key currently comes back as HTTP 404 with this body).
+    try:
+        if r.json().get("error") == "auth_error":
+            return False, f"rejected (HTTP {r.status_code}) — wrong or revoked key"
+    except ValueError:
+        pass
     return False, f"unexpected HTTP {r.status_code}"
 
 

--- a/aiod/vast.py
+++ b/aiod/vast.py
@@ -11,8 +11,9 @@ Key facts encoded here (verified against the vast-cli source):
                PER-GPU VRAM in MB; needs direct_port_count >= 1 to be reachable.
   * Create:    PUT  /api/v0/asks/{offer_id}/   ; env is a DICT, port maps are
                keys like "-p 8000:8000": "1"; returns {"new_contract": <id>}.
+  * List:      GET  /api/v1/instances/         ; the v0 list was deprecated (410).
   * Endpoint:  GET  /api/v0/instances/{id}/    ; host = public_ipaddr,
-               port = ports["8000/tcp"][0]["HostPort"].
+               port = ports["8000/tcp"][0]["HostPort"]. (single-instance still v0)
   * Destroy:   DELETE /api/v0/instances/{id}/
 """
 
@@ -216,7 +217,8 @@ class VastClient:
         return inst
 
     def list_instances(self) -> list[dict]:
-        data = self._get("/api/v0/instances/")
+        # v0 list was deprecated (410); v1 returns the same {"instances": [...]} shape.
+        data = self._get("/api/v1/instances/")
         inst = data.get("instances", [])
         return inst if isinstance(inst, list) else [inst]
 


### PR DESCRIPTION
vast.ai retired the v0 instance-list endpoint — it now returns `HTTP 410 deprecated_endpoint` ("Use /api/v1/instances/ instead"). This broke API-key validation and TUI status refresh: a valid key surfaced as a `410` / "unexpected HTTP" error when spinning up the TUI.

## Changes
- `list_instances` and `validate_vast_key` now call `/api/v1/instances/` (same `{"instances": [...]}` response shape). Single-instance `GET`/`DELETE`, `request_logs`, `asks` and `bundles` stay on v0 — verified still live.
- `validate_vast_key` now detects vast's `auth_error` body. A wrong/revoked key comes back as `HTTP 404` (not `401`), so the old 401-only check mislabelled it as an unexpected error.
- Updated the endpoint reference comment in `vast.py`.

## Verification
- Live probe: valid key → `valid (0 instance(s))`; bad key → `rejected`.
- `pytest tests/test_vast.py tests/test_onboard.py` → 10 passed.