### PR TITLE
chore: release v0.2.0 + live vendor-API smoke checks

### DIFF
--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -1,0 +1,49 @@
+name: Smoke (live API probes)
+
+# Weekly check that the vendor endpoints aiod depends on (vast.ai / RunPod /
+# HuggingFace) are still alive and unchanged — the one failure class the mocked
+# unit suite cannot catch (e.g. the v0→v1 vast deprecation that returned HTTP 410).
+#
+# Runs ONLY on a schedule and manual dispatch — never on pull_request — so fork
+# PRs can never reach the API-key secrets.
+#
+# The auth-free probes (RunPod pricing GraphQL, HuggingFace sizing) run with no
+# secrets at all. To also exercise the authenticated endpoints (incl. the vast
+# v1 instances list that broke), add VAST_API_KEY / RUNPOD_API_KEY as repo
+# Actions secrets. Note: these are billable accounts — only do so on a repo you
+# trust, and keep this workflow off pull_request triggers.
+
+on:
+  schedule:
+    - cron: "17 6 * * 1" # Mondays 06:17 UTC
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  issues: write # open an alert issue if a depended-on endpoint changed
+
+jobs:
+  smoke:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - name: Install
+        run: |
+          python -m pip install --upgrade pip
+          pip install -e ".[dev]"
+      - name: Live probes
+        env:
+          VAST_API_KEY: ${{ secrets.VAST_API_KEY }}
+          RUNPOD_API_KEY: ${{ secrets.RUNPOD_API_KEY }}
+        run: pytest tests/test_live.py -m live -v
+      - name: Open an alert issue on failure
+        if: failure()
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh issue create \
+            --title "⚠️ Live smoke failed — a vendor API aiod depends on may have changed" \
+            --body "The weekly live smoke check failed. A vast.ai / RunPod / HuggingFace endpoint that aiod depends on returned an unexpected status or response shape — exactly how the v0→v1 (HTTP 410) break would have surfaced early. Run: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "aiondemandcluster"
-version = "0.1.0"
+version = "0.2.0"
 description = "AI on Demand — spin up a HuggingFace model on vast.ai GPUs and drive it from Claude Code via Claude Code Router."
 readme = "README.md"
 requires-python = ">=3.10"
@@ -36,6 +36,14 @@ build-backend = "hatchling.build"
 
 [tool.hatch.build.targets.wheel]
 packages = ["aiod"]
+
+[tool.pytest.ini_options]
+# `live` tests hit real vendor APIs (vast/runpod/HF) and are excluded from the
+# default run so `pytest tests/` stays hermetic. Run them with `pytest -m live`.
+markers = [
+    "live: probes real vendor endpoints; excluded by default (run via `pytest -m live`)",
+]
+addopts = "-m 'not live'"
 
 [tool.ruff]
 line-length = 110

--- a/tests/test_live.py
+++ b/tests/test_live.py
@@ -1,0 +1,94 @@
+"""Live smoke probes — hit the real vendor endpoints aiod depends on, to catch
+upstream API changes (deprecations / response-shape changes) BEFORE they break
+users. This is the one failure class the mocked unit suite can't catch: PR #1
+fixed exactly such a break (vast.ai retired its v0 instance-list endpoint → 410),
+and no mocked test would ever have flagged it.
+
+These are EXCLUDED from the default run via pyproject `addopts = -m "not live"`,
+so `pytest tests/` stays hermetic and needs no network or secrets. Run them
+explicitly:
+
+    pytest -m live                          # auth-free probes (+ any with keys in env)
+    VAST_API_KEY=... RUNPOD_API_KEY=... pytest -m live   # also the authenticated paths
+
+The weekly GitHub Action (.github/workflows/smoke.yml) runs these and opens an
+issue if a depended-on endpoint changes. The auth-free probes (RunPod pricing,
+HuggingFace sizing) run there with no secrets; the vast/runpod authenticated
+probes only run if you add those API keys as repo Actions secrets.
+"""
+
+from __future__ import annotations
+
+import os
+
+import httpx
+import pytest
+
+pytestmark = pytest.mark.live
+
+VAST_KEY = os.environ.get("VAST_API_KEY", "").strip()
+RUNPOD_KEY = os.environ.get("RUNPOD_API_KEY", "").strip()
+TIMEOUT = 30.0
+
+
+# --- auth-free: the pricing / sizing paths (no secret required) --------------
+
+
+def test_runpod_gpu_types_graphql():
+    """RunPod pricing + VRAM come from the gpuTypes GraphQL query. aiod/runpod.py
+    reads memoryInGb / securePrice / secureCloud / displayName off each entry."""
+    r = httpx.post(
+        "https://api.runpod.io/graphql",
+        json={"query": "query{ gpuTypes{ id displayName memoryInGb securePrice secureCloud } }"},
+        timeout=TIMEOUT,
+    )
+    assert r.status_code == 200, f"runpod GraphQL → HTTP {r.status_code}"
+    types = r.json().get("data", {}).get("gpuTypes")
+    assert isinstance(types, list) and types, "gpuTypes empty/missing — query shape changed?"
+    needed = {"memoryInGb", "securePrice", "secureCloud", "displayName"}
+    missing = needed - set(types[0])
+    assert not missing, f"runpod gpuType fields changed; missing {missing}"
+
+
+def test_hf_model_api():
+    """Sizing reads the HuggingFace model API / file tree (aiod/sizing.py)."""
+    r = httpx.get(
+        "https://huggingface.co/api/models/Qwen/Qwen2.5-Coder-7B-Instruct",
+        timeout=TIMEOUT,
+    )
+    assert r.status_code == 200, f"HF model API → HTTP {r.status_code}"
+    assert "siblings" in r.json(), "HF model payload shape changed (no 'siblings')"
+
+
+# --- authenticated: the endpoints that actually broke (need a key) -----------
+
+
+@pytest.mark.skipif(not VAST_KEY, reason="VAST_API_KEY not set")
+def test_vast_v1_instances():
+    """The list endpoint PR #1 fixed: v0 was retired (410). Confirm v1 still
+    answers 200 with the {'instances': [...]} shape validate_vast_key relies on."""
+    from aiod.onboard import validate_vast_key
+
+    ok, msg = validate_vast_key(VAST_KEY)
+    assert ok, f"vast v1 instances probe failed: {msg}"
+
+
+@pytest.mark.skipif(not VAST_KEY, reason="VAST_API_KEY not set")
+def test_vast_bundles_search():
+    """Offer search (POST /api/v0/bundles/) is still on v0 — make sure that
+    namespace is alive and the call returns a list (the market may be thin)."""
+    from aiod.vast import VastClient
+
+    offers = VastClient(VAST_KEY).search_offers(
+        num_gpus=1, min_gpu_ram_gb=24, min_disk_gb=20, limit=1
+    )
+    assert isinstance(offers, list)
+
+
+@pytest.mark.skipif(not RUNPOD_KEY, reason="RUNPOD_API_KEY not set")
+def test_runpod_rest_pods():
+    """RunPod REST list endpoint (aiod/runpod.py uses GET /v1/pods)."""
+    from aiod.onboard import validate_runpod_key
+
+    ok, msg = validate_runpod_key(RUNPOD_KEY)
+    assert ok, f"runpod REST probe failed: {msg}"


### PR DESCRIPTION
Cuts **v0.2.0** and adds a live smoke-check for the one failure class the mocked unit suite can't catch — an upstream vendor deprecating an endpoint (PR #1 was exactly this: vast's v0 instance list started returning HTTP 410).

### What's in v0.2.0
- vast v0→v1 instances fix + `auth_error` key detection (#1)
- `--gpu` offer steering (#2)
- model download progress in `aiod status` (#3)
- **new:** live vendor-API smoke checks (this PR)

### Smoke-check
- `tests/test_live.py` — `@pytest.mark.live` probes of the real vast/runpod/HF endpoints aiod depends on. **Excluded from the default run** (`addopts -m "not live"`) so `pytest tests/` stays hermetic; run via `pytest -m live`.
- `.github/workflows/smoke.yml` — weekly + manual. Auth-free probes (runpod pricing, HF sizing) need **no secrets**; the vast/runpod authenticated probes only run if `VAST_API_KEY`/`RUNPOD_API_KEY` are added as repo Actions secrets. **Never runs on `pull_request`** so fork PRs can't reach secrets. Opens an issue on failure.

Local: `pytest tests/` → 64 passed, 5 live deselected; `pytest -m live` → vast v1 + bundles + runpod GraphQL + HF all green.