### PR TITLE
feat: stable local gateway (`aiod gateway`) + opt-in Anthropic endpoint

### DIFF
--- a/aiod/cli.py
+++ b/aiod/cli.py
@@ -10,6 +10,7 @@
 
 from __future__ import annotations
 
+import os
 import time
 import webbrowser
 
@@ -20,7 +21,7 @@ from rich.table import Table
 
 from . import branding, ccr, events, model_configs, onboard, profiles, providers, state
 from .bootstrap import CONTAINER_PORT, ServerConfig
-from .config import Settings
+from .config import Settings, persist_vllm_api_key, was_token_minted
 from .health import wait_until_ready
 from .sizing import QUANT_LABELS, size_any
 from .vast import PricedOption, recommend_disk_gb
@@ -969,6 +970,90 @@ def proxy(
         )
     except KeyboardInterrupt:
         console.print("\n[yellow]Proxy stopped[/] — any running box is left up (aiod status/teardown).")
+
+
+@app.command()
+def gateway(
+    profile: str = typer.Option(None, "--profile", "-p", help="Profile to spin on first request"),
+    model: str = typer.Option(None, "--model", help="Model to spin (if no profile)"),
+    quant: str = typer.Option(None, "--quant", "-q"),
+    provider: str = typer.Option(None, "--provider"),
+    max_price: float = typer.Option(None, "--max-price"),
+    ttl: float = typer.Option(None, "--ttl"),
+    idle: int = typer.Option(20, "--idle", help="Auto-destroy after N idle minutes"),
+    context: int = typer.Option(None, "--context"),
+    port: int = typer.Option(4000, "--port"),
+    bind: str = typer.Option("127.0.0.1", "--bind", help="Address to bind (non-loopback enforces auth)"),
+    write_ccr: bool = typer.Option(True, "--ccr/--no-ccr", help="Point CCR at the gateway"),
+    anthropic: bool = typer.Option(
+        False, "--anthropic/--no-anthropic", help="Mount native Anthropic /v1/messages (opt-in)"
+    ),
+    require_auth: bool = typer.Option(
+        False, "--require-auth/--no-require-auth", help="Enforce the bearer gate even on loopback"
+    ),
+):
+    """Run the always-on local gateway: an auto-spin-up proxy with a /healthz route,
+    a synthesized /v1/models cold path, optional native Anthropic /v1/messages
+    (--anthropic), and a loopback-default-open bearer gate."""
+    s = Settings.load()
+
+    prof = profiles.get(profile) if profile else None
+    if profile and not prof:
+        console.print(f"[red]No profile '{profile}'.[/] See [bold]aiod profile list[/].")
+        raise typer.Exit(1)
+    model = model or (prof.model if prof else None)
+    if not model:
+        console.print("[red]Provide --model or --profile.[/]")
+        raise typer.Exit(1)
+    provider = (provider or (prof.provider if prof else "vast")).lower()
+    _require_provider_key(s, provider)
+
+    if was_token_minted(s) and persist_vllm_api_key(s.vllm_api_key):
+        console.print("[dim]persisted VLLM_API_KEY to ~/.config/aiod/.env[/]")
+
+    spin_kwargs = dict(
+        model=model,
+        quant=quant or (prof.quant if prof else "bf16"),
+        provider=provider,
+        max_price=max_price if max_price is not None else (prof.max_price if prof else None),
+        ttl_hours=ttl if ttl is not None else (prof.ttl_hours if prof else None),
+        idle_minutes=idle,
+        context=context if context is not None else (prof.context if prof else None),
+        concurrency=prof.concurrency if prof else 4,
+        tool_parser=prof.tool_call_parser if prof else None,  # None -> model_configs
+        extra_args=list(prof.extra_vllm_args) if prof else [],
+    )
+
+    base = f"http://127.0.0.1:{port}/v1"
+    if write_ccr:
+        ccr.write_config(base, s.vllm_api_key, model)
+        console.print("[green]✓[/] CCR pointed at the gateway. Run [bold]ccr restart && ccr code[/].")
+
+    env_require = os.getenv("AIOD_GATEWAY_REQUIRE_AUTH", "").strip().lower() in ("1", "true", "yes", "on")
+    req_auth = bind != "127.0.0.1" or require_auth or env_require
+    console.print(
+        Panel(
+            f"Listening on [bold]http://{bind}:{port}[/]\n"
+            f"model: {model} ({spin_kwargs['quant']}) · provider: {spin_kwargs['provider']} · "
+            f"idle-shutdown: {idle}m\n"
+            f"anthropic /v1/messages: {'on' if anthropic else 'off'} · "
+            f"auth: {'enforced' if req_auth else 'loopback-open'}\n"
+            f"Routes: /healthz · /aiod/status · /v1/* · GET /v1/models (cold-synthesized)\n"
+            f"Status: [bold]aiod status[/] / the TUI / GET /aiod/status  ·  Ctrl-C stops the gateway.",
+            title="aiod gateway",
+            border_style="green",
+        )
+    )
+    from .proxy import run_gateway
+
+    try:
+        run_gateway(
+            s, spin_kwargs, idle_minutes=idle, host=bind, port=port,
+            enable_anthropic=anthropic, require_auth=req_auth,
+            on_event=lambda phase, msg: console.log(f"[{phase}] {msg}"),
+        )
+    except KeyboardInterrupt:
+        console.print("\n[yellow]Gateway stopped[/] — any running box is left up (aiod status/teardown).")
 
 
 @app.command()

--- a/aiod/config.py
+++ b/aiod/config.py
@@ -38,3 +38,28 @@ class Settings:
             max_price=float(os.getenv("AIOD_MAX_PRICE", "6.0") or 6.0),
             runpod_api_key=os.getenv("RUNPOD_API_KEY", "").strip(),
         )
+
+
+def was_token_minted(s: Settings) -> bool:
+    """True when the bearer token was freshly minted this process (VLLM_API_KEY
+    unset in the environment), so callers know to persist + warn exactly once."""
+    return s.vllm_api_key.startswith("sk-aiod-") and not os.getenv("VLLM_API_KEY")
+
+
+def persist_vllm_api_key(token: str, env_path: Path = GLOBAL_ENV) -> bool:
+    """Persist a minted bearer token to the global ~/.config/aiod/.env so CCR, the
+    gateway bearer, the upstream vLLM bearer and the chat page share one
+    deterministic token across restarts.
+
+    No-op (returns False) when VLLM_API_KEY is already set in the OS environment or
+    already present in the global .env. Returns True when it appends the token."""
+    if os.getenv("VLLM_API_KEY"):
+        return False
+    existing = env_path.read_text() if env_path.exists() else ""
+    if "VLLM_API_KEY=" in existing:
+        return False
+    env_path.parent.mkdir(parents=True, exist_ok=True)
+    sep = "" if (not existing or existing.endswith("\n")) else "\n"
+    with open(env_path, "a") as f:
+        f.write(f"{sep}VLLM_API_KEY={token}\n")
+    return True

--- a/aiod/proxy.py
+++ b/aiod/proxy.py
@@ -16,7 +16,9 @@ from __future__ import annotations
 
 import asyncio
 import json
+import os
 import time
+import uuid
 from dataclasses import asdict
 
 import httpx
@@ -26,10 +28,32 @@ from starlette.requests import Request
 from starlette.responses import JSONResponse, Response, StreamingResponse
 from starlette.routing import Route
 
-from . import engine, events, state
+from . import engine, events, state, translate
 from .config import Settings
 
 _DROP_HEADERS = {"content-length", "transfer-encoding", "content-encoding", "connection", "host"}
+
+GATEWAY_FILE = state.STATE_DIR / "gateway.json"
+
+
+def write_gateway_file(port: int, token: str) -> None:
+    """Record the live gateway so `aiod up`/`aiod chat` (PR2/PR3) can discover and
+    reuse a running gateway + its token without env plumbing."""
+    state.STATE_DIR.mkdir(parents=True, exist_ok=True)
+    GATEWAY_FILE.write_text(json.dumps({"pid": os.getpid(), "port": port, "token": token}))
+
+
+def read_gateway_file() -> dict | None:
+    if not GATEWAY_FILE.exists():
+        return None
+    try:
+        return json.loads(GATEWAY_FILE.read_text())
+    except (ValueError, OSError):
+        return None
+
+
+def clear_gateway_file() -> None:
+    GATEWAY_FILE.unlink(missing_ok=True)
 
 
 def _wants_stream(body: bytes) -> bool:
@@ -51,7 +75,17 @@ def _filter_headers(headers) -> dict:
 
 
 class Manager:
-    def __init__(self, settings: Settings, spin_kwargs: dict, idle_minutes: int | None, on_event=None):
+    def __init__(
+        self,
+        settings: Settings,
+        spin_kwargs: dict,
+        idle_minutes: int | None,
+        on_event=None,
+        *,
+        enable_anthropic: bool = False,
+        require_auth: bool = False,
+        token: str | None = None,
+    ):
         self.s = settings
         self.spin_kwargs = spin_kwargs
         self.idle_minutes = idle_minutes
@@ -59,6 +93,9 @@ class Manager:
         self.last_activity = time.time()
         self.spinning = False
         self._lock = asyncio.Lock()
+        self.enable_anthropic = enable_anthropic
+        self.require_auth = require_auth
+        self.token = token if token is not None else settings.vllm_api_key
 
     def ready_instance(self) -> state.Instance | None:
         inst = state.load()
@@ -66,12 +103,24 @@ class Manager:
             return inst
         return None
 
+    def _should_spin(self) -> bool:
+        """Spin when there's no running instance AND nothing is being created
+        (state is None) OR the saved instance is wedged in 'error' — but never
+        while a spin is already in flight or during a legitimate creating/loading
+        window."""
+        if self.spinning:
+            return False
+        if self.ready_instance() is not None:
+            return False
+        inst = state.load()
+        return inst is None or inst.status == "error"
+
     async def ensure(self) -> state.Instance | None:
         inst = self.ready_instance()
         if inst:
             return inst
         async with self._lock:
-            if not self.spinning and state.load() is None:
+            if self._should_spin():
                 self.spinning = True
                 asyncio.create_task(self._spin())
         return None
@@ -151,13 +200,31 @@ def _chunk(cid: str, created: int, model: str, *, content=None, role=None, finis
     }
 
 
-async def _forward(client: httpx.AsyncClient, inst, method, path, headers, body) -> Response:
-    url = f"{inst.base_url.rstrip('/')}/{path}"
+async def _forward(
+    manager: Manager, client: httpx.AsyncClient, inst, method, path, headers, body
+) -> Response:
+    base = inst.base_url
     try:
-        req = client.build_request(method, url, headers=_filter_headers(headers), content=body or None)
+        req = client.build_request(
+            method, f"{base.rstrip('/')}/{path}",
+            headers=_filter_headers(headers), content=body or None,
+        )
         up = await client.send(req, stream=True)
     except httpx.HTTPError as e:
-        return JSONResponse({"error": f"upstream unreachable: {e}"}, status_code=502)
+        # Endpoint churn: the box may have been replaced between resolve and send.
+        # Re-resolve ONCE and retry — but only here, before any upstream byte has
+        # been flushed; never inside the aiter loop (that would corrupt the stream).
+        new_inst = manager.ready_instance()
+        if new_inst is None or new_inst.base_url == base:
+            return JSONResponse({"error": f"upstream unreachable: {e}"}, status_code=502)
+        try:
+            req = client.build_request(
+                method, f"{new_inst.base_url.rstrip('/')}/{path}",
+                headers=_filter_headers(headers), content=body or None,
+            )
+            up = await client.send(req, stream=True)
+        except httpx.HTTPError as e2:
+            return JSONResponse({"error": f"upstream unreachable: {e2}"}, status_code=502)
     return StreamingResponse(
         up.aiter_raw(),
         status_code=up.status_code,
@@ -216,16 +283,236 @@ async def _warm_then_stream(manager: Manager, client: httpx.AsyncClient, method,
     await up.aclose()
 
 
+# --------------------------------------------------------------------------- #
+# Auth + synthesized OpenAI /v1/models
+# --------------------------------------------------------------------------- #
+
+def _check_auth(request: Request, token: str, require: bool) -> JSONResponse | None:
+    """Bearer gate. Loopback-default-OPEN: when ``require`` is False every request
+    is allowed (preserving tokenless local proxy/tui flows). When enforced, accept
+    ``Authorization: Bearer <token>`` or ``x-api-key: <token>``; otherwise 401 with
+    an OpenAI-shaped body for /v1/* and an Anthropic-shaped body for /v1/messages."""
+    if not require:
+        return None
+    provided = None
+    authz = request.headers.get("authorization")
+    if authz and authz.lower().startswith("bearer "):
+        provided = authz[len("bearer "):].strip()
+    if provided is None:
+        provided = request.headers.get("x-api-key")
+    if provided == token:
+        return None
+    if request.url.path.endswith("/v1/messages"):
+        return JSONResponse(
+            {"type": "error", "error": {"type": "authentication_error", "message": "invalid x-api-key"}},
+            status_code=401,
+        )
+    return JSONResponse(
+        {"error": {"message": "invalid api key", "type": "invalid_request_error", "code": "invalid_api_key"}},
+        status_code=401,
+    )
+
+
+def _models_list(model: str) -> JSONResponse:
+    return JSONResponse(
+        {"object": "list", "data": [{"id": model, "object": "model", "owned_by": "aiod"}]}
+    )
+
+
+# --------------------------------------------------------------------------- #
+# Native Anthropic /v1/messages (opt-in)
+# --------------------------------------------------------------------------- #
+
+def _anthropic_warming(text: str, model: str, message_id: str) -> JSONResponse:
+    """Non-streaming cold-start reply, shaped as a native Anthropic message."""
+    return JSONResponse(
+        {
+            "id": message_id,
+            "type": "message",
+            "role": "assistant",
+            "model": model,
+            "content": [{"type": "text", "text": text}],
+            "stop_reason": "end_turn",
+            "stop_sequence": None,
+            "usage": {"input_tokens": 0, "output_tokens": 0},
+        }
+    )
+
+
+def _anth_message_start(model: str, message_id: str, input_tokens: int = 0) -> str:
+    return translate._sse_event(
+        "message_start",
+        {
+            "type": "message_start",
+            "message": {
+                "id": message_id,
+                "type": "message",
+                "role": "assistant",
+                "model": model,
+                "content": [],
+                "stop_reason": None,
+                "stop_sequence": None,
+                "usage": {"input_tokens": input_tokens, "output_tokens": 0},
+            },
+        },
+    )
+
+
+def _anth_text_block_start(index: int) -> str:
+    return translate._sse_event(
+        "content_block_start",
+        {"type": "content_block_start", "index": index, "content_block": {"type": "text", "text": ""}},
+    )
+
+
+def _anth_text_delta(index: int, text: str) -> str:
+    return translate._sse_event(
+        "content_block_delta",
+        {"type": "content_block_delta", "index": index, "delta": {"type": "text_delta", "text": text}},
+    )
+
+
+def _anth_block_stop(index: int) -> str:
+    return translate._sse_event("content_block_stop", {"type": "content_block_stop", "index": index})
+
+
+def _anth_message_close(stop_reason: str = "end_turn", output_tokens: int = 0) -> list[str]:
+    return [
+        translate._sse_event(
+            "message_delta",
+            {
+                "type": "message_delta",
+                "delta": {"stop_reason": stop_reason, "stop_sequence": None},
+                "usage": {"output_tokens": output_tokens},
+            },
+        ),
+        translate._sse_event("message_stop", {"type": "message_stop"}),
+    ]
+
+
+async def _messages_nonstream_live(
+    client: httpx.AsyncClient, token: str, inst, body_openai: dict, model: str, message_id: str
+) -> Response:
+    body_openai = dict(body_openai)
+    body_openai["stream"] = False
+    body_openai.pop("stream_options", None)
+    url = f"{inst.base_url.rstrip('/')}/chat/completions"
+    try:
+        up = await client.post(url, json=body_openai, headers={"Authorization": f"Bearer {token}"})
+    except httpx.HTTPError as e:
+        return JSONResponse(
+            {"type": "error", "error": {"type": "api_error", "message": f"upstream unreachable: {e}"}},
+            status_code=502,
+        )
+    # Surface an upstream failure as a real Anthropic error instead of letting an
+    # error body (no "choices") translate into a blank, successful-looking 200.
+    if up.status_code >= 400:
+        return JSONResponse(
+            {"type": "error",
+             "error": {"type": "api_error", "message": f"upstream returned HTTP {up.status_code}"}},
+            status_code=up.status_code,
+        )
+    data = up.json()
+    return JSONResponse(translate.openai_to_anthropic(data, model=model, message_id=message_id))
+
+
+async def _messages_stream_live(
+    client: httpx.AsyncClient, token: str, inst, body_openai: dict, model: str, message_id: str
+):
+    body_openai = dict(body_openai)
+    body_openai["stream"] = True
+    body_openai.setdefault("stream_options", {"include_usage": True})
+    url = f"{inst.base_url.rstrip('/')}/chat/completions"
+    req = client.build_request(
+        "POST", url, json=body_openai, headers={"Authorization": f"Bearer {token}"}
+    )
+    up = await client.send(req, stream=True)
+    chunks = translate.iter_openai_chunks(up.aiter_lines())
+    try:
+        async for ev in translate.translate_stream(chunks, model=model, message_id=message_id):
+            yield ev
+    finally:
+        await up.aclose()
+
+
+async def _warm_then_messages(manager: Manager, client: httpx.AsyncClient, body_openai, model, message_id):
+    """Anthropic cold-start: emit exactly ONE message_start + a warming text block
+    (index 0), poll events like _warm_then_stream, then translate the real upstream
+    stream with emit_message_start=False / start_index=1 so a single envelope wraps
+    the whole response."""
+    start = time.time()
+    yield _anth_message_start(model, message_id)
+    yield _anth_text_block_start(0)
+    yield _anth_text_delta(0, f"🔄 Warming up {model}…\n")
+
+    last_phase, last_beat = None, start
+    while True:
+        if manager.ready_instance():
+            break
+        ev = events.latest()
+        phase = ev["phase"] if ev else "starting"
+        now = time.time()
+        if phase == "error":
+            detail = ev["msg"] if ev else ""
+            yield _anth_text_delta(0, f"\n❌ Warm-up failed: {detail}\n")
+            yield _anth_block_stop(0)
+            for ev_str in _anth_message_close("end_turn", 0):
+                yield ev_str
+            return
+        if phase != last_phase:
+            yield _anth_text_delta(0, f"  • {phase}: {ev['msg'] if ev else ''}\n")
+            last_phase, last_beat = phase, now
+        elif now - last_beat >= 15:
+            yield _anth_text_delta(0, f"  …still {phase} ({int(now - start)}s)\n")
+            last_beat = now
+        else:
+            yield ": keepalive\n\n"
+        await asyncio.sleep(2)
+
+    manager.last_activity = time.time()
+    yield _anth_text_delta(0, "  • ready ✓\n")
+    yield _anth_block_stop(0)
+
+    inst = manager.ready_instance()
+    body_openai = dict(body_openai)
+    body_openai["stream"] = True
+    body_openai.setdefault("stream_options", {"include_usage": True})
+    url = f"{inst.base_url.rstrip('/')}/chat/completions"
+    req = client.build_request(
+        "POST", url, json=body_openai, headers={"Authorization": f"Bearer {manager.token}"}
+    )
+    up = await client.send(req, stream=True)
+    chunks = translate.iter_openai_chunks(up.aiter_lines())
+    try:
+        async for ev_str in translate.translate_stream(
+            chunks, model=model, message_id=message_id,
+            emit_message_start=False, emit_message_stop=True, start_index=1,
+        ):
+            yield ev_str
+    finally:
+        await up.aclose()
+
+
 def build_app(manager: Manager) -> Starlette:
     async def proxy_v1(request: Request) -> Response:
+        auth = _check_auth(request, manager.token, manager.require_auth)
+        if auth is not None:
+            return auth
         path = request.path_params["path"]
-        body = await request.body()
         client: httpx.AsyncClient = request.app.state.http
 
+        # Synthesized model list on the cold path so clients that probe /v1/models
+        # before a box is live (e.g. OpenWebUI) succeed without kicking a spin.
+        if request.method == "GET" and path == "models" and manager.ready_instance() is None:
+            return _models_list(manager.spin_kwargs.get("model", "model"))
+
+        body = await request.body()
         inst = manager.ready_instance()
         if inst is not None:
             manager.last_activity = time.time()
-            return await _forward(client, inst, request.method, path, dict(request.headers), body)
+            return await _forward(
+                manager, client, inst, request.method, path, dict(request.headers), body
+            )
 
         # Cold: kick off the background spin.
         await manager.ensure()
@@ -240,6 +527,48 @@ def build_app(manager: Manager) -> Starlette:
             )
         # Non-streaming requests can't show progress — return a 'warming' message.
         return _warming_response(manager.warming_text(), False, model)
+
+    async def healthz(request: Request) -> Response:
+        return JSONResponse({"status": "up", "ready": manager.ready_instance() is not None})
+
+    async def messages(request: Request) -> Response:
+        auth = _check_auth(request, manager.token, manager.require_auth)
+        if auth is not None:
+            return auth
+        raw = await request.body()
+        try:
+            body = json.loads(raw or b"{}")
+        except (ValueError, TypeError):
+            return JSONResponse(
+                {"type": "error", "error": {"type": "invalid_request_error", "message": "invalid JSON"}},
+                status_code=400,
+            )
+        client: httpx.AsyncClient = request.app.state.http
+        body_openai = translate.anthropic_to_openai(body)
+        model = body.get("model") or manager.spin_kwargs.get("model", "model")
+        message_id = f"msg_{uuid.uuid4().hex[:24]}"
+        stream = bool(body.get("stream"))
+
+        inst = manager.ready_instance()
+        if inst is not None:
+            manager.last_activity = time.time()
+            if stream:
+                return StreamingResponse(
+                    _messages_stream_live(client, manager.token, inst, body_openai, model, message_id),
+                    media_type="text/event-stream",
+                )
+            return await _messages_nonstream_live(
+                client, manager.token, inst, body_openai, model, message_id
+            )
+
+        # Cold: kick off the background spin.
+        await manager.ensure()
+        if stream:
+            return StreamingResponse(
+                _warm_then_messages(manager, client, body_openai, model, message_id),
+                media_type="text/event-stream",
+            )
+        return _anthropic_warming(manager.warming_text(), model, message_id)
 
     async def aiod_status(request: Request) -> Response:
         inst = state.load()
@@ -265,14 +594,44 @@ def build_app(manager: Manager) -> Starlette:
             idle_task.cancel()
             await app.state.http.aclose()
 
-    app = Starlette(
-        routes=[
-            Route("/aiod/status", aiod_status, methods=["GET"]),
-            Route("/v1/{path:path}", proxy_v1, methods=["GET", "POST"]),
-        ],
-        lifespan=lifespan,
-    )
+    routes = [
+        Route("/aiod/status", aiod_status, methods=["GET"]),
+        Route("/healthz", healthz, methods=["GET"]),
+    ]
+    # /v1/messages must be registered BEFORE the /v1/{path:path} catch-all so it
+    # isn't swallowed by the OpenAI passthrough. Only mounted when opted in.
+    if manager.enable_anthropic:
+        routes.append(Route("/v1/messages", messages, methods=["POST"]))
+    routes.append(Route("/v1/{path:path}", proxy_v1, methods=["GET", "POST"]))
+
+    app = Starlette(routes=routes, lifespan=lifespan)
     return app
+
+
+def run_gateway(
+    settings: Settings,
+    spin_kwargs: dict,
+    idle_minutes: int | None,
+    *,
+    host: str = "127.0.0.1",
+    port: int = 4000,
+    enable_anthropic: bool = False,
+    require_auth: bool = False,
+    on_event=None,
+) -> None:
+    """Run the always-on local gateway. The canonical entrypoint; `aiod proxy`
+    delegates here with the Anthropic endpoint + auth disabled for back-compat."""
+    import uvicorn
+
+    manager = Manager(
+        settings, spin_kwargs, idle_minutes, on_event=on_event,
+        enable_anthropic=enable_anthropic, require_auth=require_auth,
+    )
+    write_gateway_file(port, manager.token)
+    try:
+        uvicorn.run(build_app(manager), host=host, port=port, log_level="warning")
+    finally:
+        clear_gateway_file()
 
 
 def run_proxy(
@@ -283,7 +642,9 @@ def run_proxy(
     port: int = 4000,
     on_event=None,
 ) -> None:
-    import uvicorn
-
-    manager = Manager(settings, spin_kwargs, idle_minutes, on_event=on_event)
-    uvicorn.run(build_app(manager), host=host, port=port, log_level="warning")
+    """Back-compat thin wrapper: delegates to run_gateway with the Anthropic
+    endpoint and auth gate disabled (byte-for-byte the old proxy behavior)."""
+    run_gateway(
+        settings, spin_kwargs, idle_minutes,
+        host=host, port=port, enable_anthropic=False, require_auth=False, on_event=on_event,
+    )

--- a/aiod/translate.py
+++ b/aiod/translate.py
@@ -1,0 +1,419 @@
+"""Pure-function translation between the Anthropic and OpenAI chat dialects.
+
+This module is deliberately I/O-free and side-effect-free so the riskiest part of
+the gateway (the stateful Anthropic streaming translator) can be unit-tested in
+isolation. It is consumed by the opt-in ``/v1/messages`` endpoint in proxy.py.
+
+Two directions:
+  * ``anthropic_to_openai`` — request body translation (Anthropic -> OpenAI).
+  * ``openai_to_anthropic`` / ``translate_stream`` — response translation
+    (OpenAI -> Anthropic), non-streaming and streaming respectively.
+"""
+
+from __future__ import annotations
+
+import json
+import uuid
+from collections.abc import AsyncIterator
+
+# OpenAI finish_reason -> Anthropic stop_reason.
+STOP_REASON_MAP = {
+    "stop": "end_turn",
+    "length": "max_tokens",
+    "tool_calls": "tool_use",
+}
+
+
+# --------------------------------------------------------------------------- #
+# Request translation: Anthropic -> OpenAI
+# --------------------------------------------------------------------------- #
+
+def _image_data_uri(source: dict) -> str:
+    """Anthropic image source -> an OpenAI ``image_url`` data URI (or passthrough)."""
+    if source.get("type") == "base64":
+        media = source.get("media_type", "image/png")
+        return f"data:{media};base64,{source.get('data', '')}"
+    # url source (Anthropic also supports {type:url,url:...})
+    return source.get("url", "")
+
+
+def _flatten_tool_result(block: dict) -> str:
+    """tool_result content (string | list of text blocks) -> a flat string."""
+    content = block.get("content", "")
+    if isinstance(content, str):
+        return content
+    if isinstance(content, list):
+        parts = []
+        for sub in content:
+            if isinstance(sub, dict) and sub.get("type") == "text":
+                parts.append(sub.get("text", ""))
+            elif isinstance(sub, str):
+                parts.append(sub)
+        return "".join(parts)
+    return json.dumps(content)
+
+
+def _system_to_message(system) -> dict | None:
+    """system (string | list of text blocks) -> a single OpenAI system message."""
+    if not system:
+        return None
+    if isinstance(system, str):
+        text = system
+    else:
+        text = "".join(
+            b.get("text", "") for b in system if isinstance(b, dict) and b.get("type") == "text"
+        )
+    return {"role": "system", "content": text}
+
+
+def _convert_user_content(content) -> tuple[object, list[dict]]:
+    """Returns (openai_content, tool_messages) for a user-role Anthropic message.
+
+    ``openai_content`` is a plain string when the message is text-only, otherwise a
+    list of OpenAI content parts. ``tool_messages`` are emitted as separate
+    ``role:tool`` messages (OpenAI carries tool results as their own messages).
+    """
+    if isinstance(content, str):
+        return content, []
+    parts: list[dict] = []
+    tool_messages: list[dict] = []
+    for block in content:
+        btype = block.get("type")
+        if btype == "text":
+            parts.append({"type": "text", "text": block.get("text", "")})
+        elif btype == "image":
+            parts.append(
+                {"type": "image_url", "image_url": {"url": _image_data_uri(block.get("source", {}))}}
+            )
+        elif btype == "tool_result":
+            tool_messages.append(
+                {
+                    "role": "tool",
+                    "tool_call_id": block.get("tool_use_id", ""),
+                    "content": _flatten_tool_result(block),
+                }
+            )
+    if not parts:
+        return None, tool_messages
+    if len(parts) == 1 and parts[0]["type"] == "text":
+        return parts[0]["text"], tool_messages
+    return parts, tool_messages
+
+
+def _convert_assistant_content(content) -> dict:
+    """Returns a single OpenAI assistant message (text + optional tool_calls)."""
+    if isinstance(content, str):
+        return {"role": "assistant", "content": content}
+    text_parts: list[str] = []
+    tool_calls: list[dict] = []
+    for block in content:
+        btype = block.get("type")
+        if btype == "text":
+            text_parts.append(block.get("text", ""))
+        elif btype == "tool_use":
+            tool_calls.append(
+                {
+                    "id": block.get("id", ""),
+                    "type": "function",
+                    "function": {
+                        "name": block.get("name", ""),
+                        "arguments": json.dumps(block.get("input", {})),
+                    },
+                }
+            )
+    msg: dict = {"role": "assistant", "content": "".join(text_parts) or None}
+    if tool_calls:
+        msg["tool_calls"] = tool_calls
+    return msg
+
+
+def _convert_tools(tools: list[dict]) -> list[dict]:
+    out = []
+    for t in tools:
+        out.append(
+            {
+                "type": "function",
+                "function": {
+                    "name": t.get("name", ""),
+                    "description": t.get("description", ""),
+                    "parameters": t.get("input_schema", {}),
+                },
+            }
+        )
+    return out
+
+
+def _convert_tool_choice(choice):
+    """auto -> auto, any -> required, {type:tool,name} -> forced function."""
+    if not isinstance(choice, dict):
+        return None
+    ctype = choice.get("type")
+    if ctype == "auto":
+        return "auto"
+    if ctype == "any":
+        return "required"
+    if ctype == "tool":
+        return {"type": "function", "function": {"name": choice.get("name", "")}}
+    return None
+
+
+def anthropic_to_openai(body: dict) -> dict:
+    """Translate a native Anthropic /v1/messages request into an OpenAI request."""
+    messages: list[dict] = []
+
+    sys_msg = _system_to_message(body.get("system"))
+    if sys_msg is not None:
+        messages.append(sys_msg)
+
+    for msg in body.get("messages", []):
+        role = msg.get("role")
+        content = msg.get("content", "")
+        if role == "assistant":
+            messages.append(_convert_assistant_content(content))
+        else:  # user (and any other role) carries text/image/tool_result
+            oai_content, tool_messages = _convert_user_content(content)
+            # tool results come first so they directly follow the assistant tool_calls
+            messages.extend(tool_messages)
+            if oai_content is not None:
+                messages.append({"role": "user", "content": oai_content})
+
+    out: dict = {"messages": messages}
+    if body.get("model"):
+        out["model"] = body["model"]
+    if body.get("max_tokens") is not None:
+        out["max_tokens"] = body["max_tokens"]
+    if body.get("stop_sequences"):
+        out["stop"] = body["stop_sequences"]
+    if body.get("temperature") is not None:
+        out["temperature"] = body["temperature"]
+    if body.get("top_p") is not None:
+        out["top_p"] = body["top_p"]
+    if body.get("tools"):
+        out["tools"] = _convert_tools(body["tools"])
+    tc = _convert_tool_choice(body.get("tool_choice"))
+    if tc is not None:
+        out["tool_choice"] = tc
+    if body.get("stream"):
+        out["stream"] = True
+        out["stream_options"] = {"include_usage": True}
+    return out
+
+
+# --------------------------------------------------------------------------- #
+# Response translation: OpenAI -> Anthropic (non-streaming)
+# --------------------------------------------------------------------------- #
+
+def _new_message_id() -> str:
+    return f"msg_{uuid.uuid4().hex[:24]}"
+
+
+def openai_to_anthropic(resp: dict, *, model: str, message_id: str | None = None) -> dict:
+    """Translate a non-streaming OpenAI chat completion into an Anthropic message."""
+    choices = resp.get("choices") or [{}]
+    choice = choices[0]
+    message = choice.get("message", {}) or {}
+
+    content_blocks: list[dict] = []
+    text = message.get("content")
+    if text:
+        content_blocks.append({"type": "text", "text": text})
+    for tc in message.get("tool_calls") or []:
+        fn = tc.get("function", {}) or {}
+        try:
+            args = json.loads(fn.get("arguments") or "{}")
+        except (ValueError, TypeError):
+            args = {}
+        content_blocks.append(
+            {"type": "tool_use", "id": tc.get("id", ""), "name": fn.get("name", ""), "input": args}
+        )
+
+    finish = choice.get("finish_reason")
+    stop_reason = STOP_REASON_MAP.get(finish, "end_turn") if finish else "end_turn"
+
+    usage = resp.get("usage") or {}
+    return {
+        "id": message_id or resp.get("id") or _new_message_id(),
+        "type": "message",
+        "role": "assistant",
+        "model": model,
+        "content": content_blocks,
+        "stop_reason": stop_reason,
+        "stop_sequence": None,
+        "usage": {
+            "input_tokens": usage.get("prompt_tokens", 0) or 0,
+            "output_tokens": usage.get("completion_tokens", 0) or 0,
+        },
+    }
+
+
+# --------------------------------------------------------------------------- #
+# Response translation: OpenAI -> Anthropic (streaming)
+# --------------------------------------------------------------------------- #
+
+def _sse_event(event: str, data: dict) -> str:
+    return f"event: {event}\ndata: {json.dumps(data)}\n\n"
+
+
+async def iter_openai_chunks(line_aiter) -> AsyncIterator[dict]:
+    """Parse an httpx ``aiter_lines()`` stream into OpenAI chunk dicts.
+
+    Line-buffered (so SSE events are never split across byte boundaries), tolerant
+    of blank lines and comment lines, and terminates on the ``[DONE]`` sentinel.
+    """
+    async for line in line_aiter:
+        if isinstance(line, bytes):
+            line = line.decode("utf-8", "replace")
+        line = line.strip()
+        if not line or not line.startswith("data:"):
+            continue
+        payload = line[len("data:"):].strip()
+        if payload == "[DONE]":
+            return
+        try:
+            yield json.loads(payload)
+        except (ValueError, TypeError):
+            continue
+
+
+async def translate_stream(
+    chunks,
+    *,
+    model: str,
+    message_id: str,
+    input_tokens: int = 0,
+    emit_message_start: bool = True,
+    emit_message_stop: bool = True,
+    start_index: int = 0,
+) -> AsyncIterator[str]:
+    """Stateful OpenAI-chunk -> Anthropic-SSE event machine.
+
+    Emits at most one ``message_start`` (suppressible for the cold-start seam) and
+    one terminating ``message_delta``/``message_stop``. Tracks a single open block
+    (text or tool_use), accumulating ``tool_calls[].function.arguments`` fragments
+    keyed by their OpenAI ``index`` and forwarding them as ``input_json_delta``
+    without parsing. ``output_tokens`` is read from the trailing usage chunk.
+    """
+    if emit_message_start:
+        yield _sse_event(
+            "message_start",
+            {
+                "type": "message_start",
+                "message": {
+                    "id": message_id,
+                    "type": "message",
+                    "role": "assistant",
+                    "model": model,
+                    "content": [],
+                    "stop_reason": None,
+                    "stop_sequence": None,
+                    "usage": {"input_tokens": input_tokens, "output_tokens": 0},
+                },
+            },
+        )
+
+    next_index = start_index
+    open_index: int | None = None
+    open_kind: str | None = None  # "text" | "tool_use"
+    tool_index_map: dict[int, int] = {}  # OpenAI tool_calls index -> Anthropic block index
+    output_tokens = 0
+    stop_reason = "end_turn"
+
+    def _close_open() -> str | None:
+        nonlocal open_index, open_kind
+        if open_index is None:
+            return None
+        ev = _sse_event("content_block_stop", {"type": "content_block_stop", "index": open_index})
+        open_index = None
+        open_kind = None
+        return ev
+
+    async for chunk in chunks:
+        usage = chunk.get("usage")
+        if usage:
+            output_tokens = usage.get("completion_tokens", output_tokens) or output_tokens
+
+        choices = chunk.get("choices") or []
+        if not choices:
+            continue
+        choice = choices[0]
+        delta = choice.get("delta") or {}
+
+        content = delta.get("content")
+        if content:
+            if open_kind != "text":
+                closed = _close_open()
+                if closed:
+                    yield closed
+                open_index = next_index
+                open_kind = "text"
+                next_index += 1
+                yield _sse_event(
+                    "content_block_start",
+                    {
+                        "type": "content_block_start",
+                        "index": open_index,
+                        "content_block": {"type": "text", "text": ""},
+                    },
+                )
+            yield _sse_event(
+                "content_block_delta",
+                {
+                    "type": "content_block_delta",
+                    "index": open_index,
+                    "delta": {"type": "text_delta", "text": content},
+                },
+            )
+
+        for tc in delta.get("tool_calls") or []:
+            oai_idx = tc.get("index", 0)
+            fn = tc.get("function", {}) or {}
+            if oai_idx not in tool_index_map:
+                closed = _close_open()
+                if closed:
+                    yield closed
+                open_index = next_index
+                open_kind = "tool_use"
+                tool_index_map[oai_idx] = open_index
+                next_index += 1
+                yield _sse_event(
+                    "content_block_start",
+                    {
+                        "type": "content_block_start",
+                        "index": open_index,
+                        "content_block": {
+                            "type": "tool_use",
+                            "id": tc.get("id", ""),
+                            "name": fn.get("name", ""),
+                            "input": {},
+                        },
+                    },
+                )
+            args = fn.get("arguments")
+            if args:
+                yield _sse_event(
+                    "content_block_delta",
+                    {
+                        "type": "content_block_delta",
+                        "index": tool_index_map[oai_idx],
+                        "delta": {"type": "input_json_delta", "partial_json": args},
+                    },
+                )
+
+        finish = choice.get("finish_reason")
+        if finish:
+            stop_reason = STOP_REASON_MAP.get(finish, "end_turn")
+
+    closed = _close_open()
+    if closed:
+        yield closed
+
+    yield _sse_event(
+        "message_delta",
+        {
+            "type": "message_delta",
+            "delta": {"stop_reason": stop_reason, "stop_sequence": None},
+            "usage": {"output_tokens": output_tokens},
+        },
+    )
+    if emit_message_stop:
+        yield _sse_event("message_stop", {"type": "message_stop"})

--- a/tests/test_proxy.py
+++ b/tests/test_proxy.py
@@ -1,19 +1,30 @@
 import asyncio
 
+import httpx
+from starlette.responses import JSONResponse, StreamingResponse
 from starlette.testclient import TestClient
 
 from aiod import proxy, state
 from aiod.config import Settings
 
 
-def _manager(monkeypatch):
-    # No instance + already 'spinning' so ensure() never triggers a real launch.
-    monkeypatch.setattr(state, "load", lambda: None)
-    s = Settings(
+def _settings():
+    return Settings(
         vast_api_key="k", hf_token=None, vllm_api_key="sk-x", ttl_hours=4, max_price=6.0
     )
-    m = proxy.Manager(s, {"model": "org/model", "quant": "fp8"}, idle_minutes=20)
-    m.spinning = True
+
+
+def _manager(monkeypatch, *, enable_anthropic=False, require_auth=False, spinning=True):
+    # No instance + already 'spinning' so ensure() never triggers a real launch.
+    monkeypatch.setattr(state, "load", lambda: None)
+    m = proxy.Manager(
+        _settings(),
+        {"model": "org/model", "quant": "fp8"},
+        idle_minutes=20,
+        enable_anthropic=enable_anthropic,
+        require_auth=require_auth,
+    )
+    m.spinning = spinning
     return m
 
 
@@ -57,3 +68,172 @@ def test_aiod_status_endpoint(monkeypatch):
     assert body["spinning"] is True
     assert body["idle_minutes"] == 20
     assert body["instance"] is None
+
+
+# --------------------------------------------------------------------------- #
+# /healthz
+# --------------------------------------------------------------------------- #
+
+def test_healthz_reports_not_ready_when_no_instance(monkeypatch):
+    app = proxy.build_app(_manager(monkeypatch))
+    with TestClient(app) as client:
+        r = client.get("/healthz")
+    assert r.status_code == 200
+    assert r.json() == {"status": "up", "ready": False}
+
+
+# --------------------------------------------------------------------------- #
+# Synthesized /v1/models cold path
+# --------------------------------------------------------------------------- #
+
+def test_models_synthesized_without_spin(monkeypatch):
+    m = _manager(monkeypatch, spinning=False)
+    app = proxy.build_app(m)
+    with TestClient(app) as client:
+        r = client.get("/v1/models")
+    assert r.status_code == 200
+    body = r.json()
+    assert body["object"] == "list"
+    assert body["data"][0]["id"] == "org/model"
+    assert body["data"][0]["owned_by"] == "aiod"
+    # synthesized cold path must NOT kick a spin
+    assert m.spinning is False
+
+
+# --------------------------------------------------------------------------- #
+# Auth gate
+# --------------------------------------------------------------------------- #
+
+def test_auth_loopback_open_allows_without_bearer(monkeypatch):
+    app = proxy.build_app(_manager(monkeypatch, require_auth=False))
+    with TestClient(app) as client:
+        r = client.get("/v1/models")
+    assert r.status_code == 200
+
+
+def test_auth_required_rejects_missing_bearer_openai_shape(monkeypatch):
+    app = proxy.build_app(_manager(monkeypatch, require_auth=True))
+    with TestClient(app) as client:
+        r = client.get("/v1/models")
+    assert r.status_code == 401
+    assert r.json()["error"]["code"] == "invalid_api_key"
+
+
+def test_auth_required_accepts_correct_bearer(monkeypatch):
+    app = proxy.build_app(_manager(monkeypatch, require_auth=True))
+    with TestClient(app) as client:
+        r = client.get("/v1/models", headers={"Authorization": "Bearer sk-x"})
+    assert r.status_code == 200
+
+
+def test_auth_required_messages_anthropic_shape_and_x_api_key(monkeypatch):
+    app = proxy.build_app(_manager(monkeypatch, enable_anthropic=True, require_auth=True))
+    with TestClient(app) as client:
+        missing = client.post("/v1/messages", json={"model": "org/model", "messages": []})
+        assert missing.status_code == 401
+        assert missing.json()["type"] == "error"
+        assert missing.json()["error"]["type"] == "authentication_error"
+
+        ok = client.post(
+            "/v1/messages",
+            headers={"x-api-key": "sk-x"},
+            json={"model": "org/model", "messages": [{"role": "user", "content": "hi"}]},
+        )
+        assert ok.status_code == 200
+        assert ok.json()["type"] == "message"
+
+
+# --------------------------------------------------------------------------- #
+# /v1/messages cold-start (opt-in)
+# --------------------------------------------------------------------------- #
+
+def test_messages_route_absent_without_anthropic(monkeypatch):
+    app = proxy.build_app(_manager(monkeypatch, enable_anthropic=False))
+    with TestClient(app) as client:
+        r = client.post("/v1/messages", json={"model": "org/model", "messages": []})
+    # /v1/messages falls through to the /v1/{path} catch-all, which only allows
+    # GET/POST passthrough — POST to a cold backend returns the OpenAI warming shape.
+    assert r.json().get("object") == "chat.completion"
+
+
+def test_messages_cold_nonstream_returns_anthropic_message(monkeypatch):
+    app = proxy.build_app(_manager(monkeypatch, enable_anthropic=True))
+    with TestClient(app) as client:
+        r = client.post(
+            "/v1/messages",
+            json={"model": "org/model", "messages": [{"role": "user", "content": "hi"}]},
+        )
+    assert r.status_code == 200
+    body = r.json()
+    assert body["type"] == "message"
+    assert body["role"] == "assistant"
+    assert body["content"][0]["type"] == "text"
+
+
+# --------------------------------------------------------------------------- #
+# _forward pre-first-byte re-resolve + retry
+# --------------------------------------------------------------------------- #
+
+class _FakeUpstream:
+    def __init__(self):
+        self.status_code = 200
+        self.headers = {}
+
+    async def aiter_raw(self):
+        yield b"ok"
+
+    async def aclose(self):
+        pass
+
+
+class _FakeClient:
+    """build_request returns a sentinel; send raises on the first call then
+    succeeds, so we can exercise _forward's single pre-first-byte retry."""
+
+    def __init__(self, *, raises, succeeds_after=1):
+        self.calls = 0
+        self.raises = raises
+        self.succeeds_after = succeeds_after
+
+    def build_request(self, method, url, headers=None, content=None):
+        return ("req", url)
+
+    async def send(self, req, stream=True):
+        self.calls += 1
+        if self.calls <= self.succeeds_after and self.raises:
+            raise httpx.ConnectError("boom")
+        return _FakeUpstream()
+
+
+def _inst(host, port):
+    return state.Instance(
+        instance_id=1, repo_id="org/model", quant="fp8", gpu_desc="1x H100",
+        price_per_hr=1.0, created_at=0.0, ttl_hours=4, host=host, port=port, status="running",
+    )
+
+
+def test_forward_retries_on_changed_base_url(monkeypatch):
+    m = _manager(monkeypatch)
+    new = _inst("2.2.2.2", 2222)
+    monkeypatch.setattr(m, "ready_instance", lambda: new)
+    client = _FakeClient(raises=True, succeeds_after=1)
+    old = _inst("1.1.1.1", 1111)
+    resp = asyncio.run(_forward(m, client, old))
+    assert isinstance(resp, StreamingResponse)
+    assert client.calls == 2  # first raised, retry against the new base_url succeeded
+
+
+def test_forward_502_when_base_url_unchanged(monkeypatch):
+    m = _manager(monkeypatch)
+    old = _inst("1.1.1.1", 1111)
+    monkeypatch.setattr(m, "ready_instance", lambda: old)
+    client = _FakeClient(raises=True, succeeds_after=99)
+    resp = asyncio.run(_forward(m, client, old))
+    assert isinstance(resp, JSONResponse)
+    assert resp.status_code == 502
+
+
+def _forward(manager, client, inst):
+    return proxy._forward(
+        manager, client, inst, "POST", "chat/completions", {}, b"{}"
+    )

--- a/tests/test_translate.py
+++ b/tests/test_translate.py
@@ -1,0 +1,419 @@
+"""Unit tests for the pure Anthropic<->OpenAI translation module."""
+
+import asyncio
+import json
+
+from aiod import translate
+
+# --------------------------------------------------------------------------- #
+# Async helpers
+# --------------------------------------------------------------------------- #
+
+async def _aiter(items):
+    for it in items:
+        yield it
+
+
+def _collect(agen):
+    async def run():
+        return [x async for x in agen]
+
+    return asyncio.run(run())
+
+
+def _events(sse_strings):
+    """Parse a list of SSE event strings into (event_type, data_dict) tuples,
+    skipping comment/keepalive lines."""
+    out = []
+    for s in sse_strings:
+        if not s.startswith("event:"):
+            continue
+        lines = s.splitlines()
+        etype = lines[0].split(":", 1)[1].strip()
+        data = json.loads(lines[1].split(":", 1)[1].strip())
+        out.append((etype, data))
+    return out
+
+
+# --------------------------------------------------------------------------- #
+# anthropic_to_openai
+# --------------------------------------------------------------------------- #
+
+def test_system_string_prepends_one_system_message():
+    out = translate.anthropic_to_openai(
+        {"system": "be terse", "messages": [{"role": "user", "content": "hi"}]}
+    )
+    assert out["messages"][0] == {"role": "system", "content": "be terse"}
+    assert sum(1 for m in out["messages"] if m["role"] == "system") == 1
+
+
+def test_system_blocks_prepend_one_system_message():
+    out = translate.anthropic_to_openai(
+        {
+            "system": [{"type": "text", "text": "a"}, {"type": "text", "text": "b"}],
+            "messages": [{"role": "user", "content": "hi"}],
+        }
+    )
+    systems = [m for m in out["messages"] if m["role"] == "system"]
+    assert len(systems) == 1
+    assert systems[0]["content"] == "ab"
+
+
+def test_tool_use_assistant_maps_to_tool_calls():
+    out = translate.anthropic_to_openai(
+        {
+            "messages": [
+                {
+                    "role": "assistant",
+                    "content": [
+                        {"type": "text", "text": "let me check"},
+                        {
+                            "type": "tool_use",
+                            "id": "tu_1",
+                            "name": "get_weather",
+                            "input": {"city": "NYC"},
+                        },
+                    ],
+                }
+            ]
+        }
+    )
+    msg = out["messages"][0]
+    assert msg["role"] == "assistant"
+    assert msg["content"] == "let me check"
+    tc = msg["tool_calls"][0]
+    assert tc["id"] == "tu_1"
+    assert tc["type"] == "function"
+    assert tc["function"]["name"] == "get_weather"
+    assert json.loads(tc["function"]["arguments"]) == {"city": "NYC"}
+
+
+def test_tool_result_user_maps_to_role_tool():
+    out = translate.anthropic_to_openai(
+        {
+            "messages": [
+                {
+                    "role": "user",
+                    "content": [
+                        {"type": "tool_result", "tool_use_id": "tu_1", "content": "72F"},
+                        {"type": "text", "text": "thanks"},
+                    ],
+                }
+            ]
+        }
+    )
+    tool_msg = out["messages"][0]
+    assert tool_msg["role"] == "tool"
+    assert tool_msg["tool_call_id"] == "tu_1"
+    assert tool_msg["content"] == "72F"
+    # remaining text becomes a user message after the tool message
+    assert out["messages"][1] == {"role": "user", "content": "thanks"}
+
+
+def test_tool_result_list_content_flattened():
+    out = translate.anthropic_to_openai(
+        {
+            "messages": [
+                {
+                    "role": "user",
+                    "content": [
+                        {
+                            "type": "tool_result",
+                            "tool_use_id": "tu_9",
+                            "content": [{"type": "text", "text": "part1"}, {"type": "text", "text": "part2"}],
+                        }
+                    ],
+                }
+            ]
+        }
+    )
+    assert out["messages"][0]["content"] == "part1part2"
+
+
+def test_tools_and_tool_choice_mapping():
+    out = translate.anthropic_to_openai(
+        {
+            "messages": [{"role": "user", "content": "hi"}],
+            "tools": [
+                {
+                    "name": "get_weather",
+                    "description": "Get weather",
+                    "input_schema": {"type": "object", "properties": {"city": {"type": "string"}}},
+                }
+            ],
+            "tool_choice": {"type": "tool", "name": "get_weather"},
+        }
+    )
+    tool = out["tools"][0]
+    assert tool["type"] == "function"
+    assert tool["function"]["name"] == "get_weather"
+    assert tool["function"]["description"] == "Get weather"
+    assert tool["function"]["parameters"]["type"] == "object"
+    assert out["tool_choice"] == {"type": "function", "function": {"name": "get_weather"}}
+
+
+def test_tool_choice_auto_and_any():
+    auto = translate.anthropic_to_openai(
+        {"messages": [], "tool_choice": {"type": "auto"}}
+    )
+    assert auto["tool_choice"] == "auto"
+    any_ = translate.anthropic_to_openai(
+        {"messages": [], "tool_choice": {"type": "any"}}
+    )
+    assert any_["tool_choice"] == "required"
+
+
+def test_image_block_to_data_uri():
+    out = translate.anthropic_to_openai(
+        {
+            "messages": [
+                {
+                    "role": "user",
+                    "content": [
+                        {"type": "text", "text": "what is this"},
+                        {
+                            "type": "image",
+                            "source": {"type": "base64", "media_type": "image/png", "data": "AAAA"},
+                        },
+                    ],
+                }
+            ]
+        }
+    )
+    parts = out["messages"][0]["content"]
+    assert parts[0] == {"type": "text", "text": "what is this"}
+    assert parts[1]["type"] == "image_url"
+    assert parts[1]["image_url"]["url"] == "data:image/png;base64,AAAA"
+
+
+def test_max_tokens_and_stop_sequences_mapping():
+    out = translate.anthropic_to_openai(
+        {"messages": [], "max_tokens": 128, "stop_sequences": ["STOP"]}
+    )
+    assert out["max_tokens"] == 128
+    assert out["stop"] == ["STOP"]
+
+
+def test_stream_options_injected_only_when_stream_true():
+    streamed = translate.anthropic_to_openai({"messages": [], "stream": True})
+    assert streamed["stream"] is True
+    assert streamed["stream_options"] == {"include_usage": True}
+
+    non_streamed = translate.anthropic_to_openai({"messages": [], "stream": False})
+    assert "stream" not in non_streamed
+    assert "stream_options" not in non_streamed
+
+
+# --------------------------------------------------------------------------- #
+# openai_to_anthropic (non-stream)
+# --------------------------------------------------------------------------- #
+
+def test_openai_to_anthropic_text_and_usage():
+    resp = {
+        "id": "cmpl-1",
+        "choices": [
+            {"index": 0, "message": {"role": "assistant", "content": "hello"}, "finish_reason": "stop"}
+        ],
+        "usage": {"prompt_tokens": 11, "completion_tokens": 5},
+    }
+    out = translate.openai_to_anthropic(resp, model="m", message_id="msg_x")
+    assert out["id"] == "msg_x"
+    assert out["type"] == "message"
+    assert out["role"] == "assistant"
+    assert out["model"] == "m"
+    assert out["content"] == [{"type": "text", "text": "hello"}]
+    assert out["stop_reason"] == "end_turn"
+    assert out["usage"] == {"input_tokens": 11, "output_tokens": 5}
+
+
+def test_openai_to_anthropic_tool_calls_parses_arguments():
+    resp = {
+        "choices": [
+            {
+                "index": 0,
+                "message": {
+                    "role": "assistant",
+                    "content": None,
+                    "tool_calls": [
+                        {
+                            "id": "call_1",
+                            "type": "function",
+                            "function": {"name": "lookup", "arguments": '{"q": "x"}'},
+                        }
+                    ],
+                },
+                "finish_reason": "tool_calls",
+            }
+        ],
+        "usage": {"prompt_tokens": 3, "completion_tokens": 7},
+    }
+    out = translate.openai_to_anthropic(resp, model="m")
+    assert out["stop_reason"] == "tool_use"
+    block = out["content"][0]
+    assert block == {"type": "tool_use", "id": "call_1", "name": "lookup", "input": {"q": "x"}}
+
+
+def test_openai_to_anthropic_finish_reason_length():
+    resp = {"choices": [{"message": {"content": "x"}, "finish_reason": "length"}]}
+    out = translate.openai_to_anthropic(resp, model="m")
+    assert out["stop_reason"] == "max_tokens"
+
+
+# --------------------------------------------------------------------------- #
+# iter_openai_chunks
+# --------------------------------------------------------------------------- #
+
+def test_iter_openai_chunks_tolerates_blanks_and_done():
+    lines = [
+        "",
+        ": comment",
+        'data: {"a": 1}',
+        "",
+        'data: {"b": 2}',
+        "data: [DONE]",
+        'data: {"c": 3}',  # after DONE -> must be ignored
+    ]
+    chunks = _collect(translate.iter_openai_chunks(_aiter(lines)))
+    assert chunks == [{"a": 1}, {"b": 2}]
+
+
+def test_iter_openai_chunks_handles_bytes():
+    lines = [b'data: {"a": 1}', b"data: [DONE]"]
+    chunks = _collect(translate.iter_openai_chunks(_aiter(lines)))
+    assert chunks == [{"a": 1}]
+
+
+# --------------------------------------------------------------------------- #
+# translate_stream
+# --------------------------------------------------------------------------- #
+
+def _chunk(content=None, finish=None, usage=None, role=None, tool_calls=None):
+    delta = {}
+    if role:
+        delta["role"] = role
+    if content is not None:
+        delta["content"] = content
+    if tool_calls is not None:
+        delta["tool_calls"] = tool_calls
+    ch = {"choices": [{"index": 0, "delta": delta, "finish_reason": finish}]}
+    if usage is not None:
+        ch["usage"] = usage
+        ch["choices"] = []
+    return ch
+
+
+def test_translate_stream_text_single_envelope_and_usage():
+    chunks = [
+        _chunk(role="assistant", content=""),
+        _chunk(content="Hel"),
+        _chunk(content="lo"),
+        _chunk(finish="stop"),
+        _chunk(usage={"prompt_tokens": 4, "completion_tokens": 9}),
+    ]
+    evs = _events(
+        _collect(translate.translate_stream(_aiter(chunks), model="m", message_id="msg_1"))
+    )
+    types = [e[0] for e in evs]
+    assert types == [
+        "message_start",
+        "content_block_start",
+        "content_block_delta",
+        "content_block_delta",
+        "content_block_stop",
+        "message_delta",
+        "message_stop",
+    ]
+    assert types.count("message_start") == 1
+    assert types.count("message_stop") == 1
+    # text deltas
+    deltas = [e[1]["delta"]["text"] for e in evs if e[0] == "content_block_delta"]
+    assert deltas == ["Hel", "lo"]
+    # stop_reason + output_tokens from trailing usage chunk
+    md = next(e[1] for e in evs if e[0] == "message_delta")
+    assert md["delta"]["stop_reason"] == "end_turn"
+    assert md["usage"]["output_tokens"] == 9
+    # text block opened at index 0
+    cbs = next(e[1] for e in evs if e[0] == "content_block_start")
+    assert cbs["index"] == 0
+    assert cbs["content_block"]["type"] == "text"
+
+
+def test_translate_stream_tool_calls_input_json_delta():
+    chunks = [
+        _chunk(
+            tool_calls=[
+                {
+                    "index": 0,
+                    "id": "call_1",
+                    "type": "function",
+                    "function": {"name": "lookup", "arguments": ""},
+                }
+            ]
+        ),
+        _chunk(tool_calls=[{"index": 0, "function": {"arguments": '{"q":'}}]),
+        _chunk(tool_calls=[{"index": 0, "function": {"arguments": ' "x"}'}}]),
+        _chunk(finish="tool_calls"),
+        _chunk(usage={"completion_tokens": 3}),
+    ]
+    evs = _events(
+        _collect(translate.translate_stream(_aiter(chunks), model="m", message_id="msg_2"))
+    )
+    types = [e[0] for e in evs]
+    assert types[0] == "message_start"
+    assert types[-1] == "message_stop"
+    start = next(e[1] for e in evs if e[0] == "content_block_start")
+    assert start["content_block"] == {"type": "tool_use", "id": "call_1", "name": "lookup", "input": {}}
+    json_deltas = [
+        e[1]["delta"]["partial_json"]
+        for e in evs
+        if e[0] == "content_block_delta" and e[1]["delta"]["type"] == "input_json_delta"
+    ]
+    assert json_deltas == ['{"q":', ' "x"}']
+    md = next(e[1] for e in evs if e[0] == "message_delta")
+    assert md["delta"]["stop_reason"] == "tool_use"
+    assert md["usage"]["output_tokens"] == 3
+
+
+def test_translate_stream_text_then_tool_closes_first_block():
+    chunks = [
+        _chunk(content="thinking"),
+        _chunk(
+            tool_calls=[
+                {"index": 0, "id": "c1", "type": "function", "function": {"name": "f", "arguments": "{}"}}
+            ]
+        ),
+        _chunk(finish="tool_calls"),
+    ]
+    evs = _events(
+        _collect(translate.translate_stream(_aiter(chunks), model="m", message_id="msg_3"))
+    )
+    # text block index 0, tool_use block index 1
+    starts = [e[1] for e in evs if e[0] == "content_block_start"]
+    assert starts[0]["index"] == 0 and starts[0]["content_block"]["type"] == "text"
+    assert starts[1]["index"] == 1 and starts[1]["content_block"]["type"] == "tool_use"
+    stops = [e[1]["index"] for e in evs if e[0] == "content_block_stop"]
+    assert stops == [0, 1]
+
+
+def test_translate_stream_cold_envelope_no_message_start_start_index_1():
+    chunks = [
+        _chunk(content="hi"),
+        _chunk(finish="stop"),
+    ]
+    evs = _events(
+        _collect(
+            translate.translate_stream(
+                _aiter(chunks),
+                model="m",
+                message_id="msg_4",
+                emit_message_start=False,
+                emit_message_stop=True,
+                start_index=1,
+            )
+        )
+    )
+    types = [e[0] for e in evs]
+    assert "message_start" not in types
+    assert types[-1] == "message_stop"
+    cbs = next(e[1] for e in evs if e[0] == "content_block_start")
+    assert cbs["index"] == 1


### PR DESCRIPTION
**PR 1 of 3** in the gateway stack (designed via a multi-agent workflow; implemented + adversarially reviewed by another).

Promotes the auto-spin proxy into an always-on **stable local gateway** so CCR, the chat UI, and any OpenAI/Anthropic client point at one fixed URL while the ephemeral remote box rotates behind it.

### What's in it
- **`aiod/translate.py` (new, pure functions):** OpenAI↔Anthropic translation — system/content blocks, tools + tool_choice, stop-reason map, non-stream + streaming (tool_use `input_json_delta` accumulation + trailing usage). Fully unit-tested in isolation.
- **`aiod gateway`** (via `run_gateway()`): loopback-default-open bearer auth (enforced off-loopback or `AIOD_GATEWAY_REQUIRE_AUTH=1`), `/healthz`, synthesized `/v1/models` cold path, and an **opt-in** native `/v1/messages` endpoint (`--anthropic`, default **off** — keeps the stateful translator off the critical path).
- Endpoint churn handled by re-resolving state per request + a **pre-first-byte-only** retry (never mid-stream, so the SSE envelope is never corrupted).
- `persist_vllm_api_key()` so the minted `sk-aiod-*` token is shared across CCR, the gateway, and the upstream container.

### Safety
- **`aiod proxy` kept working** (thin wrapper). Claude Code stays on CCR — your normal `claude`/real-Anthropic usage is untouched.
- Native Anthropic endpoint is opt-in; the default paths are the proven OpenAI passthrough.

### Tests
29 new (translate matrix + auth/healthz/models/messages/forward-retry). **93 passing, ruff clean.**

Reviewer caught + fixed: the `AIOD_GATEWAY_REQUIRE_AUTH` toggle (was a no-op) and upstream errors masking as blank 200s on the Anthropic path.