### PR TITLE
feat: `aiod up <hf-link>` — one-command spin + CCR wiring

### DIFF
--- a/aiod/__main__.py
+++ b/aiod/__main__.py
@@ -1,0 +1,6 @@
+"""Enable ``python -m aiod`` (used by `aiod up --detach` to spawn the gateway)."""
+
+from .cli import app
+
+if __name__ == "__main__":
+    app()

--- a/aiod/cli.py
+++ b/aiod/cli.py
@@ -11,6 +11,8 @@
 from __future__ import annotations
 
 import os
+import subprocess
+import sys
 import time
 import webbrowser
 
@@ -23,6 +25,7 @@ from . import branding, ccr, events, model_configs, onboard, profiles, providers
 from .bootstrap import CONTAINER_PORT, ServerConfig
 from .config import Settings, persist_vllm_api_key, was_token_minted
 from .health import wait_until_ready
+from .hf import parse_repo_id
 from .sizing import QUANT_LABELS, size_any
 from .vast import PricedOption, recommend_disk_gb
 
@@ -991,6 +994,9 @@ def gateway(
     require_auth: bool = typer.Option(
         False, "--require-auth/--no-require-auth", help="Enforce the bearer gate even on loopback"
     ),
+    eager_spin: bool = typer.Option(
+        False, "--eager-spin/--no-eager-spin", help="Warm the box at startup, not on first request"
+    ),
 ):
     """Run the always-on local gateway: an auto-spin-up proxy with a /healthz route,
     a synthesized /v1/models cold path, optional native Anthropic /v1/messages
@@ -1049,11 +1055,153 @@ def gateway(
     try:
         run_gateway(
             s, spin_kwargs, idle_minutes=idle, host=bind, port=port,
-            enable_anthropic=anthropic, require_auth=req_auth,
+            enable_anthropic=anthropic, require_auth=req_auth, eager_spin=eager_spin,
             on_event=lambda phase, msg: console.log(f"[{phase}] {msg}"),
         )
     except KeyboardInterrupt:
         console.print("\n[yellow]Gateway stopped[/] — any running box is left up (aiod status/teardown).")
+
+
+@app.command()
+def up(
+    link: str = typer.Argument(
+        ..., help="HuggingFace URL or repo id (org/repo), or a known profile name"
+    ),
+    profile: str = typer.Option(None, "--profile", "-p", help="Use a named profile's settings"),
+    quant: str = typer.Option(None, "--quant", "-q"),
+    provider: str = typer.Option(None, "--provider"),
+    max_price: float = typer.Option(None, "--max-price"),
+    ttl: float = typer.Option(None, "--ttl"),
+    idle: int = typer.Option(20, "--idle", help="Auto-destroy after N idle minutes"),
+    context: int = typer.Option(None, "--context"),
+    port: int = typer.Option(4000, "--port"),
+    write_ccr: bool = typer.Option(True, "--ccr/--no-ccr", help="Point CCR at the local gateway"),
+    anthropic: bool = typer.Option(
+        False, "--anthropic/--no-anthropic", help="Mount native Anthropic /v1/messages (opt-in)"
+    ),
+    detach: bool = typer.Option(False, "--detach", help="Run the gateway in the background"),
+    no_spin: bool = typer.Option(False, "--no-spin", help="Don't eagerly warm the box at startup"),
+):
+    """One command: resolve a model, point CCR at the stable local gateway, start
+    the gateway, and eagerly warm the box. `aiod up org/repo`."""
+    s = Settings.load()
+
+    # Resolve the profile either from --profile or from a bare `link` that names one.
+    prof = profiles.get(profile) if profile else profiles.get(link)
+    if profile and not prof:
+        console.print(f"[red]No profile '{profile}'.[/] See [bold]aiod profile list[/].")
+        raise typer.Exit(1)
+
+    if prof:
+        model = prof.model
+    else:
+        try:
+            model = parse_repo_id(link)
+        except ValueError as e:
+            console.print(f"[red]{e}[/]")
+            raise typer.Exit(1) from None
+
+    provider = (provider or (prof.provider if prof else "vast")).lower()
+    _require_provider_key(s, provider)
+
+    if was_token_minted(s) and persist_vllm_api_key(s.vllm_api_key):
+        console.print("[dim]persisted VLLM_API_KEY to ~/.config/aiod/.env[/]")
+
+    spin_kwargs = dict(
+        model=model,
+        quant=quant or (prof.quant if prof else "bf16"),
+        provider=provider,
+        max_price=max_price if max_price is not None else (prof.max_price if prof else None),
+        ttl_hours=ttl if ttl is not None else (prof.ttl_hours if prof else None),
+        idle_minutes=idle,
+        context=context if context is not None else (prof.context if prof else None),
+        concurrency=prof.concurrency if prof else 4,
+        tool_parser=prof.tool_call_parser if prof else None,  # None -> model_configs
+        extra_args=list(prof.extra_vllm_args) if prof else [],
+    )
+
+    # Wire CCR at the STABLE local gateway URL — never the rotating box — so CCR
+    # stops churning on every respin.
+    base = f"http://127.0.0.1:{port}/v1"
+    if write_ccr:
+        ccr.write_config(base, s.vllm_api_key, model)
+        console.print("[green]✓[/] CCR pointed at the local gateway. Run [bold]ccr restart && ccr code[/].")
+
+    console.print(
+        Panel(
+            f"model: [bold]{model}[/] ({spin_kwargs['quant']}) · provider: {provider} · "
+            f"idle-shutdown: {idle}m\n"
+            f"gateway: [bold]http://127.0.0.1:{port}[/]\n\n"
+            f"Next steps:\n"
+            f"  • [bold]ccr restart && ccr code[/]  (drive the model from Claude Code)\n"
+            f"  • [bold]aiod chat[/]                 (built-in chat UI)\n"
+            f"  • [bold]aiod status[/]               (live spin-up progress / cost)",
+            title="aiod up",
+            border_style="green",
+        )
+    )
+
+    if detach:
+        cmd = [
+            sys.executable, "-m", "aiod", "gateway",
+            "--model", model,
+            "--quant", spin_kwargs["quant"],
+            "--provider", provider,
+            "--idle", str(idle),
+            "--port", str(port),
+            "--no-ccr",  # already wired above; don't double-write
+        ]
+        # Forward the profile so the child rebuilds the SAME spin_kwargs —
+        # concurrency (feeds size_model/cost), tool_parser, and extra_vllm_args
+        # are profile-derived and have no standalone gateway flags.
+        prof_name = profile or (link if prof else None)
+        if prof_name:
+            cmd += ["--profile", prof_name]
+        if spin_kwargs["max_price"] is not None:
+            cmd += ["--max-price", str(spin_kwargs["max_price"])]
+        if spin_kwargs["ttl_hours"] is not None:
+            cmd += ["--ttl", str(spin_kwargs["ttl_hours"])]
+        if spin_kwargs["context"] is not None:
+            cmd += ["--context", str(spin_kwargs["context"])]
+        if anthropic:
+            cmd += ["--anthropic"]
+        if not no_spin:
+            cmd += ["--eager-spin"]  # match foreground: warm the box now, not on first request
+        proc = subprocess.Popen(cmd, start_new_session=True)
+        console.print(f"[dim]gateway started in background (pid {proc.pid}). Polling /healthz…[/]")
+        if _poll_healthz(port):
+            console.print("[green]✓[/] gateway is up.")
+        else:
+            console.print("[yellow]gateway did not report healthy in time — check [bold]aiod status[/].[/]")
+        return
+
+    from .proxy import run_gateway
+
+    try:
+        run_gateway(
+            s, spin_kwargs, idle_minutes=idle, port=port,
+            enable_anthropic=anthropic, eager_spin=not no_spin,
+            on_event=lambda phase, msg: console.log(f"[{phase}] {msg}"),
+        )
+    except KeyboardInterrupt:
+        console.print("\n[yellow]Gateway stopped[/] — any running box is left up (aiod status/teardown).")
+
+
+def _poll_healthz(port: int, timeout: float = 30.0) -> bool:
+    """Poll the detached gateway's /healthz until it reports up (or times out)."""
+    import httpx
+
+    deadline = time.time() + timeout
+    url = f"http://127.0.0.1:{port}/healthz"
+    while time.time() < deadline:
+        try:
+            r = httpx.get(url, timeout=2.0)
+            if r.status_code == 200 and r.json().get("status") == "up":
+                return True
+        except (httpx.HTTPError, ValueError):
+            pass
+        time.sleep(1.0)
+    return False
 
 
 @app.command()

--- a/aiod/hf.py
+++ b/aiod/hf.py
@@ -1,0 +1,80 @@
+"""Hugging Face link parsing (pure, no I/O).
+
+Kept separate from cli.py so the URL-variant matrix is unit-testable.
+"""
+
+from __future__ import annotations
+
+import re
+from urllib.parse import urlparse
+
+# Reserved leading path segments on huggingface.co that are NOT model repos.
+# We reject these loudly rather than silently producing a bad repo id.
+_RESERVED = {
+    "datasets",
+    "spaces",
+    "models",
+    "organizations",
+    "settings",
+    "join",
+    "login",
+    "logout",
+    "blog",
+    "docs",
+    "pricing",
+    "api",
+    "new",
+    "search",
+}
+
+_HF_HOSTS = {"huggingface.co", "www.huggingface.co", "hf.co"}
+
+# A single repo-id segment: alphanumerics plus . _ -
+_SEGMENT = re.compile(r"[A-Za-z0-9][A-Za-z0-9._-]*")
+
+
+def parse_repo_id(link: str) -> str:
+    """Normalize a Hugging Face model reference to ``'org/repo'``.
+
+    Accepts:
+      * full URLs: ``https://huggingface.co/org/repo`` (with ``/tree/...``,
+        ``/resolve/...``, ``?query`` or ``#fragment`` suffixes),
+      * bare ``org/repo``.
+
+    Raises ``ValueError`` on unparseable input and on Spaces/datasets (or any
+    other non-model namespace) URLs — never returns a bad id silently.
+    """
+    if not isinstance(link, str) or not link.strip():
+        raise ValueError(f"empty Hugging Face reference: {link!r}")
+
+    s = link.strip()
+
+    if "://" in s or s.lower().startswith(tuple(h + "/" for h in _HF_HOSTS)):
+        candidate = s if "://" in s else "https://" + s
+        parsed = urlparse(candidate)
+        host = parsed.netloc.lower()
+        if host not in _HF_HOSTS:
+            raise ValueError(f"not a Hugging Face URL (host {host!r}): {link!r}")
+        path = parsed.path
+    else:
+        # Bare form; drop any query/fragment that snuck in.
+        path = s.split("#", 1)[0].split("?", 1)[0]
+
+    parts = [p for p in path.split("/") if p]
+    if len(parts) < 2:
+        raise ValueError(f"could not parse 'org/repo' from {link!r}")
+
+    org, repo = parts[0], parts[1]
+
+    if org.lower() in _RESERVED:
+        raise ValueError(
+            f"not a model repo (looks like a '{org}' page, not a model): {link!r}"
+        )
+
+    # Strip a revision pin (org/repo@sha) if present.
+    repo = repo.split("@", 1)[0]
+
+    if not _SEGMENT.fullmatch(org) or not _SEGMENT.fullmatch(repo):
+        raise ValueError(f"invalid org/repo in {link!r}")
+
+    return f"{org}/{repo}"

--- a/aiod/proxy.py
+++ b/aiod/proxy.py
@@ -493,7 +493,7 @@ async def _warm_then_messages(manager: Manager, client: httpx.AsyncClient, body_
         await up.aclose()
 
 
-def build_app(manager: Manager) -> Starlette:
+def build_app(manager: Manager, *, eager_spin: bool = False) -> Starlette:
     async def proxy_v1(request: Request) -> Response:
         auth = _check_auth(request, manager.token, manager.require_auth)
         if auth is not None:
@@ -588,6 +588,11 @@ def build_app(manager: Manager) -> Starlette:
     async def lifespan(app: Starlette):
         app.state.http = httpx.AsyncClient(timeout=httpx.Timeout(None))
         idle_task = asyncio.create_task(manager.idle_monitor())
+        # `aiod up` warms the box before the first request arrives so the cold
+        # start overlaps with the user reading the next-steps panel. Default off
+        # (gateway/proxy) so there is no behavior change.
+        if eager_spin:
+            asyncio.create_task(manager.ensure())
         try:
             yield
         finally:
@@ -617,10 +622,14 @@ def run_gateway(
     port: int = 4000,
     enable_anthropic: bool = False,
     require_auth: bool = False,
+    eager_spin: bool = False,
     on_event=None,
 ) -> None:
     """Run the always-on local gateway. The canonical entrypoint; `aiod proxy`
-    delegates here with the Anthropic endpoint + auth disabled for back-compat."""
+    delegates here with the Anthropic endpoint + auth disabled for back-compat.
+
+    When ``eager_spin`` is True the manager kicks one ``ensure()`` at startup so
+    the box begins warming before the first request (used by ``aiod up``)."""
     import uvicorn
 
     manager = Manager(
@@ -629,7 +638,10 @@ def run_gateway(
     )
     write_gateway_file(port, manager.token)
     try:
-        uvicorn.run(build_app(manager), host=host, port=port, log_level="warning")
+        uvicorn.run(
+            build_app(manager, eager_spin=eager_spin),
+            host=host, port=port, log_level="warning",
+        )
     finally:
         clear_gateway_file()
 

--- a/tests/test_cli_up.py
+++ b/tests/test_cli_up.py
@@ -1,0 +1,118 @@
+import inspect
+from types import SimpleNamespace
+
+import pytest
+from typer.testing import CliRunner
+
+from aiod import ccr, engine, profiles, proxy
+from aiod.cli import app
+
+runner = CliRunner()
+
+
+@pytest.fixture
+def wired(monkeypatch):
+    """Stub out the side-effecting pieces of `aiod up` and capture the wiring."""
+    calls = {}
+
+    fake_settings = SimpleNamespace(vllm_api_key="sk-aiod-test123")
+    monkeypatch.setattr("aiod.cli.Settings.load", staticmethod(lambda: fake_settings))
+    monkeypatch.setattr("aiod.cli._require_provider_key", lambda s, provider: None)
+    monkeypatch.setattr("aiod.cli.was_token_minted", lambda s: False)
+    # Default: no profile resolves (HF-link path). Tests override as needed.
+    monkeypatch.setattr(profiles, "get", lambda name: None)
+
+    def fake_write_config(base_url, api_key, model):
+        calls["ccr"] = (base_url, api_key, model)
+
+    def fake_run_gateway(s, spin_kwargs, idle_minutes, **kwargs):
+        calls["run_gateway"] = {
+            "settings": s,
+            "spin_kwargs": spin_kwargs,
+            "idle_minutes": idle_minutes,
+            "kwargs": kwargs,
+        }
+
+    monkeypatch.setattr(ccr, "write_config", fake_write_config)
+    monkeypatch.setattr(proxy, "run_gateway", fake_run_gateway)
+
+    return calls
+
+
+def test_up_wires_ccr_local_base_and_parsed_model(wired):
+    result = runner.invoke(app, ["up", "meta-llama/Llama-3.1-8B-Instruct", "--port", "4000"])
+    assert result.exit_code == 0, result.output
+    base, api_key, model = wired["ccr"]
+    assert base == "http://127.0.0.1:4000/v1"
+    assert api_key == "sk-aiod-test123"
+    assert model == "meta-llama/Llama-3.1-8B-Instruct"
+
+
+def test_up_wires_ccr_with_custom_port(wired):
+    result = runner.invoke(app, ["up", "org/repo", "--port", "5005"])
+    assert result.exit_code == 0, result.output
+    base, _, _ = wired["ccr"]
+    assert base == "http://127.0.0.1:5005/v1"
+
+
+def test_up_full_url_is_parsed(wired):
+    result = runner.invoke(app, ["up", "https://huggingface.co/org/repo/tree/main"])
+    assert result.exit_code == 0, result.output
+    assert wired["ccr"][2] == "org/repo"
+
+
+def test_up_spin_kwargs_match_engine_launch_signature(wired):
+    result = runner.invoke(app, ["up", "org/repo"])
+    assert result.exit_code == 0, result.output
+    spin_kwargs = wired["run_gateway"]["spin_kwargs"]
+    launch_params = set(inspect.signature(engine.launch).parameters) - {"s", "on_event"}
+    assert set(spin_kwargs) == launch_params
+
+
+def test_up_eager_spin_passed_to_run_gateway(wired):
+    result = runner.invoke(app, ["up", "org/repo"])
+    assert result.exit_code == 0, result.output
+    assert wired["run_gateway"]["kwargs"]["eager_spin"] is True
+
+
+def test_up_no_spin_disables_eager_spin(wired):
+    result = runner.invoke(app, ["up", "org/repo", "--no-spin"])
+    assert result.exit_code == 0, result.output
+    assert wired["run_gateway"]["kwargs"]["eager_spin"] is False
+
+
+def test_up_no_ccr_skips_write_config(wired):
+    result = runner.invoke(app, ["up", "org/repo", "--no-ccr"])
+    assert result.exit_code == 0, result.output
+    assert "ccr" not in wired
+    # gateway still starts
+    assert "run_gateway" in wired
+
+
+def test_up_profile_name_resolves_model_via_profiles_get(wired, monkeypatch):
+    fake_profile = SimpleNamespace(
+        name="coder-7b",
+        model="Qwen/Qwen2.5-Coder-7B-Instruct",
+        provider="vast",
+        quant="bf16",
+        max_price=0.6,
+        ttl_hours=None,
+        context=None,
+        concurrency=4,
+        tool_call_parser=None,
+        extra_vllm_args=[],
+    )
+    monkeypatch.setattr(
+        profiles, "get", lambda name: fake_profile if name == "coder-7b" else None
+    )
+    result = runner.invoke(app, ["up", "coder-7b"])
+    assert result.exit_code == 0, result.output
+    assert wired["ccr"][2] == "Qwen/Qwen2.5-Coder-7B-Instruct"
+    assert wired["run_gateway"]["spin_kwargs"]["model"] == "Qwen/Qwen2.5-Coder-7B-Instruct"
+    assert wired["run_gateway"]["spin_kwargs"]["quant"] == "bf16"
+
+
+def test_up_garbage_link_exits_nonzero(wired):
+    result = runner.invoke(app, ["up", "this is not valid"])
+    assert result.exit_code != 0
+    assert "run_gateway" not in wired

--- a/tests/test_hf.py
+++ b/tests/test_hf.py
@@ -1,0 +1,51 @@
+import pytest
+
+from aiod.hf import parse_repo_id
+
+
+@pytest.mark.parametrize(
+    "link,expected",
+    [
+        ("meta-llama/Llama-3.1-8B-Instruct", "meta-llama/Llama-3.1-8B-Instruct"),
+        ("https://huggingface.co/meta-llama/Llama-3.1-8B-Instruct", "meta-llama/Llama-3.1-8B-Instruct"),
+        ("https://huggingface.co/meta-llama/Llama-3.1-8B-Instruct/", "meta-llama/Llama-3.1-8B-Instruct"),
+        ("https://huggingface.co/org/repo/tree/main", "org/repo"),
+        ("https://huggingface.co/org/repo/resolve/main/config.json", "org/repo"),
+        ("https://huggingface.co/org/repo?library=transformers", "org/repo"),
+        ("https://huggingface.co/org/repo#usage", "org/repo"),
+        ("http://huggingface.co/org/repo", "org/repo"),
+        ("https://www.huggingface.co/org/repo", "org/repo"),
+        ("https://hf.co/org/repo", "org/repo"),
+        ("huggingface.co/org/repo", "org/repo"),
+        ("org/repo@abc123", "org/repo"),
+        ("  org/repo  ", "org/repo"),
+    ],
+)
+def test_parse_repo_id_ok(link, expected):
+    assert parse_repo_id(link) == expected
+
+
+@pytest.mark.parametrize(
+    "link",
+    [
+        "",
+        "   ",
+        "not a url",
+        "single",
+        "https://huggingface.co/spaces/org/repo",
+        "https://huggingface.co/datasets/org/repo",
+        "https://huggingface.co/models/org",
+        "https://example.com/org/repo",
+        "https://github.com/org/repo",
+        "spaces/org/repo",
+        "datasets/org/repo",
+    ],
+)
+def test_parse_repo_id_raises(link):
+    with pytest.raises(ValueError):
+        parse_repo_id(link)
+
+
+def test_parse_repo_id_rejects_non_string():
+    with pytest.raises(ValueError):
+        parse_repo_id(None)  # type: ignore[arg-type]


### PR DESCRIPTION
**PR 2 of 3** in the gateway stack (builds on #6).

One command replaces `estimate` → `spin` → `ccr-config` → *now run ccr*: paste a HuggingFace link (or a profile name) and aiod sizes it, starts the stable local gateway, points CCR at the fixed `127.0.0.1` URL (so CCR stops churning on every respin), and eagerly warms the box.

- **`aiod/hf.py` (new)** `parse_repo_id()` — full HF URLs (`/tree`, `/resolve`, `?query`, `#frag`, `@revision`) + bare `org/repo`; rejects Spaces/datasets/reserved namespaces + non-HF hosts with `ValueError` rather than a bad id.
- **`aiod up`** (foreground or `--detach`): reuses the exact `engine.launch` spin_kwargs contract; `--no-ccr` opt-out. `--detach` forwards `--profile` (so the background box matches foreground) and `--eager-spin` unless `--no-spin`, polls `/healthz`, reports the pid.
- `run_gateway(..., eager_spin=False)` + a `--eager-spin` flag on `gateway` (default off → no behavior change).
- **`aiod/__main__.py` (new)** so `python -m aiod` works for the detached spawn.

### Tests
34 new (parse_repo_id matrix + `up` wiring/contract incl. spin_kwargs-keys==engine.launch introspection). **127 passing, ruff clean.**

Reviewer caught + fixed: `--detach` was dropping the profile's concurrency/tool_parser/extra_args (divergent box) and not eager-warming.