### PR TITLE
feat: `aiod chat` — built-in browser UI + `--webui` OpenWebUI (v0.3.0)

### DIFF
--- a/aiod/cli.py
+++ b/aiod/cli.py
@@ -1204,6 +1204,91 @@ def _poll_healthz(port: int, timeout: float = 30.0) -> bool:
     return False
 
 
+def _docker_available() -> bool:
+    try:
+        r = subprocess.run(
+            ["docker", "version", "--format", "{{.Server.Version}}"],
+            capture_output=True, timeout=10,
+        )
+        return r.returncode == 0
+    except (OSError, subprocess.SubprocessError):
+        return False
+
+
+def _ensure_gateway_detached(port: int) -> bool:
+    """Return True once a gateway answers /healthz on ``port`` — reusing a running
+    one if gateway.json points at it, else starting one detached (like `up`)."""
+    from .proxy import read_gateway_file
+
+    gw = read_gateway_file()
+    if gw and gw.get("port") == port and _poll_healthz(port, timeout=2.0):
+        return True
+    if _poll_healthz(port, timeout=2.0):
+        return True
+    console.print(f"[dim]No gateway on :{port} — starting one in the background…[/]")
+    cmd = [sys.executable, "-m", "aiod", "gateway", "--port", str(port), "--no-ccr"]
+    proc = subprocess.Popen(cmd, start_new_session=True)
+    console.print(f"[dim]gateway pid {proc.pid}; polling /healthz…[/]")
+    return _poll_healthz(port)
+
+
+@app.command()
+def chat(
+    port: int = typer.Option(4000, "--port", help="Gateway port to chat against"),
+    webui: bool = typer.Option(False, "--webui", help="Launch OpenWebUI in Docker instead of built-in page"),
+    webui_port: int = typer.Option(3000, "--webui-port", help="Host port for OpenWebUI"),
+    stop: bool = typer.Option(False, "--stop", help="Stop the OpenWebUI container (with --webui)"),
+    open_browser: bool = typer.Option(True, "--open/--no-open", help="Open the chat UI in a browser"),
+):
+    """Open a chat UI against the gateway. Default: the built-in no-Docker page
+    served at http://127.0.0.1:<port>/. --webui launches OpenWebUI in Docker."""
+    from .proxy import read_gateway_file, webui_docker_cmd
+
+    if webui:
+        if stop:
+            subprocess.run(["docker", "rm", "-f", "aiod-openwebui"], capture_output=True)
+            console.print("[green]✓[/] OpenWebUI container stopped.")
+            return
+        if not _docker_available():
+            console.print(
+                "[red]Docker is not available.[/] Install/start Docker, or use the built-in "
+                "page: [bold]aiod chat[/] (no Docker)."
+            )
+            raise typer.Exit(1)
+        if not _ensure_gateway_detached(port):
+            console.print("[yellow]Gateway did not report healthy — check [bold]aiod status[/].[/]")
+            raise typer.Exit(1)
+        gw = read_gateway_file()
+        token = gw.get("token", "") if gw else ""
+        # Idempotent: reuse the container by name if it's already there.
+        existing = subprocess.run(
+            ["docker", "ps", "-aq", "-f", "name=^aiod-openwebui$"], capture_output=True, text=True
+        )
+        if existing.returncode == 0 and existing.stdout.strip():
+            subprocess.run(["docker", "start", "aiod-openwebui"], capture_output=True)
+            console.print("[green]✓[/] reused existing OpenWebUI container.")
+        else:
+            res = subprocess.run(webui_docker_cmd(port, webui_port, token), capture_output=True, text=True)
+            if res.returncode != 0:
+                console.print(f"[red]Failed to start OpenWebUI:[/] {res.stderr.strip()}")
+                raise typer.Exit(1)
+            console.print("[green]✓[/] OpenWebUI started.")
+        url = f"http://127.0.0.1:{webui_port}"
+        console.print(f"OpenWebUI: [bold]{url}[/]  (gateway /v1 via host.docker.internal:{port})")
+        if open_browser:
+            _maybe_open(url)
+        return
+
+    # Built-in page.
+    if not _ensure_gateway_detached(port):
+        console.print("[yellow]Gateway did not report healthy — check [bold]aiod status[/].[/]")
+        raise typer.Exit(1)
+    url = f"http://127.0.0.1:{port}/"
+    console.print(f"Chat UI: [bold]{url}[/]")
+    if open_browser:
+        _maybe_open(url)
+
+
 @app.command()
 def bench(
     n: int = typer.Option(8, "--n", help="Number of requests"),

--- a/aiod/proxy.py
+++ b/aiod/proxy.py
@@ -15,8 +15,10 @@ Progress is also written to the shared events log, so `aiod status` / the TUI /
 from __future__ import annotations
 
 import asyncio
+import importlib.resources
 import json
 import os
+import sys
 import time
 import uuid
 from dataclasses import asdict
@@ -25,7 +27,7 @@ import httpx
 from starlette.applications import Starlette
 from starlette.background import BackgroundTask
 from starlette.requests import Request
-from starlette.responses import JSONResponse, Response, StreamingResponse
+from starlette.responses import HTMLResponse, JSONResponse, Response, StreamingResponse
 from starlette.routing import Route
 
 from . import engine, events, state, translate
@@ -320,6 +322,48 @@ def _models_list(model: str) -> JSONResponse:
 
 
 # --------------------------------------------------------------------------- #
+# Built-in chat page (served at / and /chat) + OpenWebUI docker helper
+# --------------------------------------------------------------------------- #
+
+def _load_chat_html() -> str:
+    """Read the packaged chat page via importlib.resources so it works from an
+    installed wheel (where aiod/web/chat.html ships as package data)."""
+    return (importlib.resources.files("aiod") / "web" / "chat.html").read_text(encoding="utf-8")
+
+
+def render_chat_page(manager: Manager) -> str:
+    """Inject the model and (only on a loopback/auth-open bind) the bearer token
+    into the chat page. On a non-loopback / require_auth bind the token is left
+    blank so it is never leaked into a page that could be served off-host."""
+    html = _load_chat_html()
+    token = "" if manager.require_auth else (manager.token or "")
+    model = manager.spin_kwargs.get("model", "model")
+    # json.dumps gives a safe, quoted JS literal so an unusual model/token string
+    # can't break out of the literal (the template no longer wraps these in quotes).
+    return html.replace("__AIOD_TOKEN__", json.dumps(token)).replace(
+        "__AIOD_MODEL__", json.dumps(model)
+    )
+
+
+def webui_docker_cmd(gw_port: int, webui_port: int, token: str) -> list[str]:
+    """Build the `docker run` argv for OpenWebUI pointed at the local gateway's
+    /v1. Pure (no side effects) so the invocation is unit-testable."""
+    cmd = [
+        "docker", "run", "-d",
+        "--name", "aiod-openwebui",
+        "-p", f"{webui_port}:8080",
+        "-e", f"OPENAI_API_BASE_URL=http://host.docker.internal:{gw_port}/v1",
+        "-e", f"OPENAI_API_KEY={token}",
+        "-e", "WEBUI_AUTH=False",
+    ]
+    # On Linux host.docker.internal isn't resolvable by default; wire it explicitly.
+    if sys.platform.startswith("linux"):
+        cmd += ["--add-host=host.docker.internal:host-gateway"]
+    cmd.append("ghcr.io/open-webui/open-webui:main")
+    return cmd
+
+
+# --------------------------------------------------------------------------- #
 # Native Anthropic /v1/messages (opt-in)
 # --------------------------------------------------------------------------- #
 
@@ -531,6 +575,13 @@ def build_app(manager: Manager, *, eager_spin: bool = False) -> Starlette:
     async def healthz(request: Request) -> Response:
         return JSONResponse({"status": "up", "ready": manager.ready_instance() is not None})
 
+    async def chat_page(request: Request) -> Response:
+        """Serve the self-contained chat page. It streams from the OpenAI
+        passthrough (/v1/chat/completions), so it works without --anthropic and
+        reuses the _warm_then_stream cold-start UX. Token is injected only on a
+        loopback/auth-open bind (see render_chat_page)."""
+        return HTMLResponse(render_chat_page(manager))
+
     async def messages(request: Request) -> Response:
         auth = _check_auth(request, manager.token, manager.require_auth)
         if auth is not None:
@@ -600,6 +651,8 @@ def build_app(manager: Manager, *, eager_spin: bool = False) -> Starlette:
             await app.state.http.aclose()
 
     routes = [
+        Route("/", chat_page, methods=["GET"]),
+        Route("/chat", chat_page, methods=["GET"]),
         Route("/aiod/status", aiod_status, methods=["GET"]),
         Route("/healthz", healthz, methods=["GET"]),
     ]

--- a/aiod/web/chat.html
+++ b/aiod/web/chat.html
@@ -1,0 +1,314 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>aiod chat</title>
+<style>
+  :root {
+    --bg: #0f1115;
+    --panel: #161a21;
+    --border: #262c38;
+    --text: #e6e9ef;
+    --muted: #8b93a3;
+    --accent: #5b9dff;
+    --user: #1f2733;
+    --assistant: #14181f;
+    --green: #3fb950;
+    --amber: #d29922;
+  }
+  * { box-sizing: border-box; }
+  html, body { height: 100%; margin: 0; }
+  body {
+    background: var(--bg);
+    color: var(--text);
+    font: 15px/1.55 -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+    display: flex;
+    flex-direction: column;
+    height: 100vh;
+  }
+  header {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    padding: 12px 18px;
+    border-bottom: 1px solid var(--border);
+    background: var(--panel);
+  }
+  header .title { font-weight: 600; letter-spacing: .2px; }
+  header .model { color: var(--muted); font-size: 13px; }
+  .status {
+    margin-left: auto;
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    font-size: 12px;
+    color: var(--muted);
+  }
+  .dot { width: 9px; height: 9px; border-radius: 50%; background: var(--muted); }
+  .dot.ready { background: var(--green); }
+  .dot.warming { background: var(--amber); animation: pulse 1.2s infinite; }
+  @keyframes pulse { 0%,100% { opacity: 1; } 50% { opacity: .35; } }
+  main {
+    flex: 1;
+    overflow-y: auto;
+    padding: 22px 0;
+  }
+  #log { max-width: 820px; margin: 0 auto; padding: 0 18px; }
+  .msg { display: flex; gap: 12px; padding: 14px 0; border-bottom: 1px solid rgba(255,255,255,.04); }
+  .msg .role {
+    flex: 0 0 64px;
+    font-size: 12px;
+    text-transform: uppercase;
+    letter-spacing: .5px;
+    color: var(--muted);
+    padding-top: 2px;
+  }
+  .msg.user .role { color: var(--accent); }
+  .msg .body { flex: 1; white-space: pre-wrap; word-wrap: break-word; }
+  .msg .body code {
+    background: #0b0d11;
+    padding: 1px 5px;
+    border-radius: 4px;
+    font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+    font-size: 13px;
+  }
+  .msg .body pre {
+    background: #0b0d11;
+    border: 1px solid var(--border);
+    border-radius: 8px;
+    padding: 12px 14px;
+    overflow-x: auto;
+  }
+  .msg .body pre code { background: none; padding: 0; }
+  .cursor::after { content: "▋"; color: var(--muted); animation: blink 1s steps(2) infinite; }
+  @keyframes blink { 0%,100% { opacity: 1; } 50% { opacity: 0; } }
+  footer {
+    border-top: 1px solid var(--border);
+    background: var(--panel);
+    padding: 12px 18px;
+  }
+  .composer { max-width: 820px; margin: 0 auto; display: flex; gap: 10px; align-items: flex-end; }
+  textarea {
+    flex: 1;
+    resize: none;
+    background: var(--bg);
+    color: var(--text);
+    border: 1px solid var(--border);
+    border-radius: 10px;
+    padding: 11px 13px;
+    font: inherit;
+    max-height: 200px;
+    min-height: 44px;
+  }
+  textarea:focus { outline: none; border-color: var(--accent); }
+  button {
+    background: var(--accent);
+    color: #0b0d11;
+    border: none;
+    border-radius: 10px;
+    padding: 0 18px;
+    height: 44px;
+    font-weight: 600;
+    cursor: pointer;
+  }
+  button:disabled { opacity: .5; cursor: not-allowed; }
+  .hint { max-width: 820px; margin: 6px auto 0; color: var(--muted); font-size: 12px; }
+</style>
+</head>
+<body>
+  <header>
+    <span class="title">aiod chat</span>
+    <span class="model" id="model"></span>
+    <div class="status">
+      <span class="dot" id="dot"></span>
+      <span id="statusText">connecting…</span>
+    </div>
+  </header>
+  <main><div id="log"></div></main>
+  <footer>
+    <div class="composer">
+      <textarea id="input" placeholder="Send a message…  (Enter to send, Shift+Enter for newline)" rows="1"></textarea>
+      <button id="send">Send</button>
+    </div>
+    <div class="hint" id="hint"></div>
+  </footer>
+
+<script>
+// Values injected by the gateway at serve time. On a non-loopback bind the token
+// placeholder is intentionally left blank (no token leak); the user supplies it.
+const TOKEN = __AIOD_TOKEN__;
+const MODEL = __AIOD_MODEL__;
+
+const logEl = document.getElementById("log");
+const inputEl = document.getElementById("input");
+const sendEl = document.getElementById("send");
+const modelEl = document.getElementById("model");
+const dotEl = document.getElementById("dot");
+const statusText = document.getElementById("statusText");
+const hintEl = document.getElementById("hint");
+
+modelEl.textContent = MODEL ? MODEL : "";
+const history = [];
+let busy = false;
+
+// --- minimal, safe markdown (escape first, then a few inline/block rules) ---
+function escapeHtml(s) {
+  return s.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
+}
+function renderMarkdown(src) {
+  const blocks = src.split(/```/);
+  let out = "";
+  for (let i = 0; i < blocks.length; i++) {
+    if (i % 2 === 1) {
+      out += "<pre><code>" + escapeHtml(blocks[i].replace(/^[a-zA-Z0-9_-]*\n/, "")) + "</code></pre>";
+    } else {
+      let t = escapeHtml(blocks[i]);
+      t = t.replace(/`([^`]+)`/g, "<code>$1</code>");
+      t = t.replace(/\*\*([^*]+)\*\*/g, "<strong>$1</strong>");
+      out += t;
+    }
+  }
+  return out;
+}
+
+function addMessage(role, text) {
+  const msg = document.createElement("div");
+  msg.className = "msg " + role;
+  const r = document.createElement("div");
+  r.className = "role";
+  r.textContent = role === "user" ? "you" : "model";
+  const body = document.createElement("div");
+  body.className = "body";
+  body.textContent = text || "";
+  msg.appendChild(r);
+  msg.appendChild(body);
+  logEl.appendChild(msg);
+  scrollDown();
+  return body;
+}
+
+function scrollDown() {
+  const main = document.querySelector("main");
+  main.scrollTop = main.scrollHeight;
+}
+
+async function poll() {
+  try {
+    const r = await fetch("/aiod/status", { headers: authHeaders() });
+    if (r.ok) {
+      const s = await r.json();
+      const ready = s.instance && s.instance.status === "running" && s.instance.base_url;
+      if (ready) {
+        dotEl.className = "dot ready";
+        statusText.textContent = "ready";
+      } else if (s.spinning) {
+        const ev = (s.events && s.events.length) ? s.events[s.events.length - 1] : null;
+        dotEl.className = "dot warming";
+        statusText.textContent = ev ? ("warming · " + ev.phase) : "warming…";
+      } else {
+        dotEl.className = "dot";
+        statusText.textContent = "idle (will warm on send)";
+      }
+    }
+  } catch (e) {
+    dotEl.className = "dot";
+    statusText.textContent = "gateway unreachable";
+  }
+}
+
+function authHeaders() {
+  const h = { "Content-Type": "application/json" };
+  if (TOKEN) h["Authorization"] = "Bearer " + TOKEN;
+  return h;
+}
+
+async function send() {
+  const text = inputEl.value.trim();
+  if (!text || busy) return;
+  busy = true;
+  sendEl.disabled = true;
+  inputEl.value = "";
+  inputEl.style.height = "auto";
+
+  addMessage("user", text);
+  history.push({ role: "user", content: text });
+
+  const body = addMessage("assistant", "");
+  body.classList.add("cursor");
+  let acc = "";
+
+  try {
+    const resp = await fetch("/v1/chat/completions", {
+      method: "POST",
+      headers: authHeaders(),
+      body: JSON.stringify({ model: MODEL, messages: history, stream: true }),
+    });
+    if (!resp.ok || !resp.body) {
+      const errText = await resp.text().catch(() => resp.statusText);
+      acc = "⚠️ request failed (" + resp.status + "): " + errText;
+      body.textContent = acc;
+    } else {
+      const reader = resp.body.getReader();
+      const decoder = new TextDecoder();
+      let buf = "";
+      while (true) {
+        const { value, done } = await reader.read();
+        if (done) break;
+        buf += decoder.decode(value, { stream: true });
+        // SSE events are delimited by blank lines.
+        let idx;
+        while ((idx = buf.indexOf("\n\n")) !== -1) {
+          const event = buf.slice(0, idx);
+          buf = buf.slice(idx + 2);
+          for (const line of event.split("\n")) {
+            const trimmed = line.trim();
+            if (!trimmed.startsWith("data:")) continue;
+            const payload = trimmed.slice(5).trim();
+            if (payload === "[DONE]") continue;
+            try {
+              const json = JSON.parse(payload);
+              const delta = json.choices && json.choices[0] && json.choices[0].delta;
+              if (delta && delta.content) {
+                acc += delta.content;
+                body.innerHTML = renderMarkdown(acc);
+                scrollDown();
+              }
+            } catch (e) { /* ignore non-JSON keepalives */ }
+          }
+        }
+      }
+    }
+  } catch (e) {
+    acc = acc || ("⚠️ " + e.message);
+    body.textContent = acc;
+  } finally {
+    body.classList.remove("cursor");
+    body.innerHTML = renderMarkdown(acc);
+    history.push({ role: "assistant", content: acc });
+    busy = false;
+    sendEl.disabled = false;
+    inputEl.focus();
+    poll();
+  }
+}
+
+sendEl.addEventListener("click", send);
+inputEl.addEventListener("keydown", (e) => {
+  if (e.key === "Enter" && !e.shiftKey) {
+    e.preventDefault();
+    send();
+  }
+});
+inputEl.addEventListener("input", () => {
+  inputEl.style.height = "auto";
+  inputEl.style.height = Math.min(inputEl.scrollHeight, 200) + "px";
+});
+
+hintEl.textContent = "Streams from /v1/chat/completions — the first message warms the GPU (cold start may take a few minutes).";
+poll();
+setInterval(poll, 4000);
+inputEl.focus();
+</script>
+</body>
+</html>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "aiondemandcluster"
-version = "0.2.0"
+version = "0.3.0"
 description = "AI on Demand — spin up a HuggingFace model on vast.ai GPUs and drive it from Claude Code via Claude Code Router."
 readme = "README.md"
 requires-python = ">=3.10"
@@ -36,6 +36,9 @@ build-backend = "hatchling.build"
 
 [tool.hatch.build.targets.wheel]
 packages = ["aiod"]
+# Ship the built-in chat page so an installed build can serve `aiod chat`.
+include = ["aiod/web/*.html"]
+artifacts = ["aiod/web/*.html"]
 
 [tool.pytest.ini_options]
 # `live` tests hit real vendor APIs (vast/runpod/HF) and are excluded from the

--- a/tests/test_chat.py
+++ b/tests/test_chat.py
@@ -1,0 +1,105 @@
+import importlib.resources
+
+from starlette.testclient import TestClient
+
+from aiod import proxy, state
+from aiod.config import Settings
+
+
+def _settings():
+    return Settings(
+        vast_api_key="k", hf_token=None, vllm_api_key="sk-aiod-secret", ttl_hours=4, max_price=6.0
+    )
+
+
+def _manager(monkeypatch, *, require_auth=False):
+    monkeypatch.setattr(state, "load", lambda: None)
+    m = proxy.Manager(
+        _settings(),
+        {"model": "org/cool-model", "quant": "fp8"},
+        idle_minutes=20,
+        require_auth=require_auth,
+    )
+    m.spinning = True
+    return m
+
+
+# --------------------------------------------------------------------------- #
+# chat_page rendering + routing
+# --------------------------------------------------------------------------- #
+
+def test_chat_page_returns_html_with_model_replaced(monkeypatch):
+    app = proxy.build_app(_manager(monkeypatch))
+    with TestClient(app) as client:
+        r = client.get("/")
+    assert r.status_code == 200
+    assert "text/html" in r.headers["content-type"]
+    assert "org/cool-model" in r.text
+    assert "__AIOD_MODEL__" not in r.text
+
+
+def test_chat_route_also_serves_page(monkeypatch):
+    app = proxy.build_app(_manager(monkeypatch))
+    with TestClient(app) as client:
+        root = client.get("/")
+        chat = client.get("/chat")
+    assert root.status_code == 200
+    assert chat.status_code == 200
+    # Same rendered page from both routes.
+    assert chat.text == root.text
+    assert "org/cool-model" in chat.text
+
+
+def test_token_injected_on_loopback(monkeypatch):
+    app = proxy.build_app(_manager(monkeypatch, require_auth=False))
+    with TestClient(app) as client:
+        r = client.get("/")
+    assert "sk-aiod-secret" in r.text
+    assert "__AIOD_TOKEN__" not in r.text
+
+
+def test_token_not_leaked_when_require_auth(monkeypatch):
+    """No-leak: on a non-loopback / require_auth bind the bearer token must NOT
+    be embedded in the served HTML."""
+    app = proxy.build_app(_manager(monkeypatch, require_auth=True))
+    with TestClient(app) as client:
+        r = client.get("/")
+    assert r.status_code == 200
+    assert "sk-aiod-secret" not in r.text
+    assert "__AIOD_TOKEN__" not in r.text  # placeholder still replaced (with empty)
+
+
+# --------------------------------------------------------------------------- #
+# webui_docker_cmd
+# --------------------------------------------------------------------------- #
+
+def test_webui_docker_cmd_wires_gateway_and_token():
+    cmd = proxy.webui_docker_cmd(4000, 3000, "sk-aiod-secret")
+    joined = " ".join(cmd)
+    assert "OPENAI_API_BASE_URL=http://host.docker.internal:4000/v1" in cmd
+    assert "OPENAI_API_KEY=sk-aiod-secret" in cmd
+    assert "WEBUI_AUTH=False" in cmd
+    # -p host:container mapping
+    i = cmd.index("-p")
+    assert cmd[i + 1] == "3000:8080"
+    assert "--name" in cmd and "aiod-openwebui" in cmd
+    assert cmd[-1] == "ghcr.io/open-webui/open-webui:main"
+    assert "docker run -d" in joined
+
+
+def test_webui_docker_cmd_custom_ports():
+    cmd = proxy.webui_docker_cmd(5005, 8888, "tok")
+    assert "OPENAI_API_BASE_URL=http://host.docker.internal:5005/v1" in cmd
+    i = cmd.index("-p")
+    assert cmd[i + 1] == "8888:8080"
+
+
+# --------------------------------------------------------------------------- #
+# package data is readable via importlib.resources (installed-build contract)
+# --------------------------------------------------------------------------- #
+
+def test_chat_html_readable_via_importlib_resources():
+    html = (importlib.resources.files("aiod") / "web" / "chat.html").read_text(encoding="utf-8")
+    assert "__AIOD_MODEL__" in html
+    assert "__AIOD_TOKEN__" in html
+    assert "/v1/chat/completions" in html


### PR DESCRIPTION
**PR 3 of 3** — closes the gateway stack (builds on #6, #7).

A one-command chat UI against the stable gateway.
- **Default:** a self-contained **no-Docker** page served at `/` (and `/chat`). Streams from the proven OpenAI passthrough `/v1/chat/completions` so it reuses the gateway's cold-start "warming up" UX — deliberately **not** the opt-in `/v1/messages`, keeping the translator off the chat path.
- **`--webui`:** launches **OpenWebUI** in Docker pointed at the gateway (`host.docker.internal:<gw>/v1`, host-gateway on Linux); `--stop` tears it down.

Security: the bearer token is injected (as a `json.dumps`'d JS literal) **only on a loopback bind** — never leaked on a non-loopback bind.

Also bumps **v0.3.0** (the whole gateway stack ships in this release).

### Tests
7 new (chat_page render, token no-leak, webui_docker_cmd, route map, package-data readable). **134 passing, ruff clean.** Reviewer: no must-fix; the injected values are now `json.dumps`-escaped (defensive).