### PR TITLE
feat: pluggable optimization layer (`--opt`) — KV-cache fp8, prefix caching + plugin interface

### DIFF
--- a/aiod/bootstrap.py
+++ b/aiod/bootstrap.py
@@ -44,6 +44,8 @@ class ServerConfig:
     gpu_memory_utilization: float = 0.92
     tool_call_parser: str = "hermes"
     extra_args: list[str] = field(default_factory=list)
+    optimizations: list[str] = field(default_factory=list)  # resolved opt keys
+    opt_values: dict[str, str] = field(default_factory=dict)  # {key: value} for value-bearing opts
     hf_token: str | None = None
     gguf_quant: str | None = None  # llamacpp: the GGUF quant tag, e.g. "UD-IQ1_M"
 
@@ -74,6 +76,14 @@ class ServerConfig:
             args += ["--quantization", flag]
         if self.max_model_len:
             args += ["--max-model-len", str(self.max_model_len)]
+        # Optimization flags go JUST BEFORE extra_args so extra_args still wins.
+        # Empty list => byte-identical argv to before.
+        if self.optimizations:
+            from . import optimizations
+            ctx = optimizations.OptContext(
+                engine=self.engine, quant=self.quant, repo_id=self.repo_id
+            )
+            args += optimizations.vllm_flags(self.optimizations, self.opt_values, ctx)
         args += self.extra_args
         return args
 
@@ -90,6 +100,12 @@ class ServerConfig:
             "--jinja",              # enable OpenAI tool/function calling
             "-c", str(self.max_model_len or 32768),
         ]
+        if self.optimizations:
+            from . import optimizations
+            ctx = optimizations.OptContext(
+                engine=self.engine, quant=self.quant, repo_id=self.repo_id
+            )
+            args += optimizations.llamacpp_flags(self.optimizations, self.opt_values, ctx)
         args += self.extra_args
         return args
 

--- a/aiod/cli.py
+++ b/aiod/cli.py
@@ -21,7 +21,17 @@ from rich.console import Console
 from rich.panel import Panel
 from rich.table import Table
 
-from . import branding, ccr, events, model_configs, onboard, profiles, providers, state
+from . import (
+    branding,
+    ccr,
+    events,
+    model_configs,
+    onboard,
+    optimizations,
+    profiles,
+    providers,
+    state,
+)
 from .bootstrap import CONTAINER_PORT, ServerConfig
 from .config import Settings, persist_vllm_api_key, was_token_minted
 from .health import wait_until_ready
@@ -39,7 +49,45 @@ console = Console()
 profile_app = typer.Typer(no_args_is_help=True, help="Manage spin-up profiles (named presets).")
 app.add_typer(profile_app, name="profile")
 
+opt_app = typer.Typer(no_args_is_help=True, help="Inspect serving/sizing optimizations.")
+app.add_typer(opt_app, name="opt")
+
 ONLINE_QUANTS = {"bf16", "fp16", "fp8"}  # work on any repo; int4 needs a pre-quantized checkpoint
+
+
+# --------------------------------------------------------------------------- #
+# Optimization selection helpers
+# --------------------------------------------------------------------------- #
+
+def _opt_tokens(opt_flags: list[str] | None, prof) -> list[str]:
+    """Resolution: --opt  >  profile.optimizations  >  default_selection()."""
+    if opt_flags:
+        return list(opt_flags)
+    if prof and getattr(prof, "optimizations", None):
+        return list(prof.optimizations)
+    return optimizations.default_selection()
+
+
+def _validate_opts(raw: list[str]) -> tuple[list[str], dict[str, str]]:
+    """Parse + validate opt tokens against the registry; exit listing valid keys
+    on an unknown key (mirrors the quant-error convention)."""
+    keys, values = optimizations.parse_selection(raw)
+    reg = optimizations.registry()
+    for k in keys:
+        if k not in reg:
+            valid = ", ".join(sorted(reg.keys()))
+            console.print(f"[red]Unknown optimization '{k}'.[/] Valid keys: {valid}")
+            raise typer.Exit(1)
+    try:
+        # Surface conflicts/value-misuse early (engine-agnostic check).
+        optimizations.resolve(
+            keys, values,
+            optimizations.OptContext(engine="vllm", quant="bf16", repo_id="org/model"),
+        )
+    except ValueError as e:
+        console.print(f"[red]Invalid optimization selection:[/] {e}")
+        raise typer.Exit(1) from e
+    return keys, values
 
 
 # --------------------------------------------------------------------------- #
@@ -240,15 +288,28 @@ def estimate(
     gpu: list[str] = typer.Option(
         None, "--gpu", help="Only consider GPUs whose name contains this (repeatable), e.g. --gpu 'rtx 6000'"
     ),
+    opt: list[str] = typer.Option(
+        None, "--opt", help="Optimization KEY or KEY=VAL (repeatable); see `aiod opt list`"
+    ),
 ):
     """Size a model from its HuggingFace link and show live provider cost ($0)."""
     provider = provider.lower()
     s = Settings.load()
     _require_provider_key(s, provider)
+    opt_keys, opt_values = _validate_opts(_opt_tokens(opt, None))
     with console.status("Fetching model metadata from HuggingFace..."):
         sizing = size_any(
             model, engine=engine, hf_token=s.hf_token, quants=quant,
             context_len=context, concurrency=concurrency,
+            opts=opt_keys, opt_values=opt_values,
+        )
+        # Baseline (no opts) so we can show the payoff side-by-side.
+        baseline = (
+            size_any(
+                model, engine=engine, hf_token=s.hf_token, quants=quant,
+                context_len=context, concurrency=concurrency,
+            )
+            if opt_keys else sizing
         )
     m = sizing.model
 
@@ -275,6 +336,10 @@ def estimate(
     table.add_column("$/hr", justify="right")
     table.add_column("$/4h", justify="right")
 
+    def _tier_of(plan) -> str:
+        cf = plan.cheapest_fit if plan else None
+        return f"{cf.num_gpus}x {cf.tier.name}" if cf else "—"
+
     max_p = max_price if max_price is not None else s.max_price
     try:
         with providers.get_client(provider, s) as client:
@@ -290,11 +355,21 @@ def estimate(
                         four = f"${best.offer.dph_total * 4:.2f}"
                     else:
                         fit, hr, four = "[red]no offer found[/]", "—", "—"
-                    table.add_row(f"{p.quant}", f"{p.required_vram_gb:.0f} GB", fit, hr, four)
+                    if opt_keys:
+                        b = baseline.plan(p.quant)
+                        vram = f"{b.required_vram_gb:.0f}→{p.required_vram_gb:.0f} GB"
+                        bt, pt = _tier_of(b), _tier_of(p)
+                        if bt != pt:
+                            fit = f"{bt} → {pt}"
+                    else:
+                        vram = f"{p.required_vram_gb:.0f} GB"
+                    table.add_row(f"{p.quant}", vram, fit, hr, four)
     except providers.PROVIDER_ERRORS as e:
         console.print(f"[red]{provider} error:[/] {e}")
         raise typer.Exit(1) from e
     console.print(table)
+    if opt_keys:
+        console.print(f"[dim]Opts: {' '.join(_opt_tokens(opt, None))} (baseline → optimized)[/]")
     console.print(
         "[dim]Tip: int4 (awq/gptq) needs a pre-quantized repo; fp8 works online on any model.[/]"
     )
@@ -323,6 +398,9 @@ def spin(
     ),
     context: int = typer.Option(None, "--context", help="Max model length to serve"),
     concurrency: int = typer.Option(None, "--concurrency", help="Concurrency for KV sizing"),
+    opt: list[str] = typer.Option(
+        None, "--opt", help="Optimization KEY or KEY=VAL (repeatable); see `aiod opt list`"
+    ),
     yes: bool = typer.Option(False, "--yes", "-y", help="Skip the confirmation prompt"),
     no_ccr: bool = typer.Option(False, "--no-ccr", help="Don't touch the CCR config"),
     dry_run: bool = typer.Option(
@@ -361,6 +439,7 @@ def spin(
     mc = model_configs.resolve(model)
     tool_parser = (prof.tool_call_parser if prof and prof.tool_call_parser else None) or mc.tool_call_parser
     extra_args = (list(prof.extra_vllm_args) if prof else []) + mc.vllm_serving_args()
+    opt_keys, opt_values = _validate_opts(_opt_tokens(opt, prof))
 
     if state.load() is not None:
         console.print(
@@ -378,6 +457,7 @@ def spin(
         sizing = size_any(
             model, engine=engine, hf_token=s.hf_token,
             quants=[quant] if quant else None, context_len=context, concurrency=concurrency,
+            opts=opt_keys, opt_values=opt_values,
         )
     eng = sizing.engine
     m = sizing.model
@@ -434,6 +514,8 @@ def spin(
             max_model_len=context,
             tool_call_parser=tool_parser,
             extra_args=extra_args,
+            optimizations=opt_keys,
+            opt_values=opt_values,
             hf_token=s.hf_token,
             gguf_quant=quant if eng == "llamacpp" else None,
         )
@@ -907,6 +989,54 @@ def profile_path():
     console.print(str(profiles.PROFILE_FILE))
 
 
+# --------------------------------------------------------------------------- #
+# opt subcommands
+# --------------------------------------------------------------------------- #
+
+@opt_app.command("list")
+def opt_list(
+    model: str = typer.Argument(None, help="Optional HF model to test applicability/sizing against"),
+):
+    """List available optimizations (and, with MODEL, how they apply to it)."""
+    spec = None
+    if model:
+        s = Settings.load()
+        try:
+            from .sizing import fetch_model_spec
+            with console.status(f"Fetching {model} metadata..."):
+                spec = fetch_model_spec(model, hf_token=s.hf_token)
+        except Exception as e:  # noqa: BLE001 - listing is informational
+            console.print(f"[yellow]![/] Couldn't fetch {model}: {e} — showing engine support only.")
+            spec = None
+
+    table = Table(title="Optimizations")
+    for col in ("Key", "Engines", "Default", "Applies", "Sizing", "Summary", "Trade-off"):
+        table.add_column(col)
+    for o in optimizations.enumerate_all():
+        ctx = optimizations.OptContext(
+            engine="vllm", quant="bf16", repo_id=model or "org/model", spec=spec,
+        )
+        applies = "[green]yes[/]" if o.applies(ctx) else "[dim]no[/]"
+        knobs = o.sizing(optimizations.SizingKnobs(), ctx)
+        parts = []
+        if knobs.kv_scale != 1.0:
+            parts.append(f"kv×{knobs.kv_scale:g}")
+        if knobs.weight_scale != 1.0:
+            parts.append(f"wt×{knobs.weight_scale:g}")
+        sizing_s = ", ".join(parts) if parts else "—"
+        table.add_row(
+            o.key,
+            ",".join(o.engines),
+            "on" if o.default_on else "off",
+            applies,
+            sizing_s,
+            o.summary,
+            o.tradeoff,
+        )
+    console.print(table)
+    console.print("[dim]Use one: [bold]aiod spin <model> --opt kv-cache-fp8 --opt max-num-seqs=256[/][/]")
+
+
 @app.command()
 def proxy(
     profile: str = typer.Option(None, "--profile", "-p", help="Profile to spin on first request"),
@@ -946,6 +1076,7 @@ def proxy(
         concurrency=prof.concurrency if prof else 4,
         tool_parser=prof.tool_call_parser if prof else None,  # None -> model_configs
         extra_args=list(prof.extra_vllm_args) if prof else [],
+        optimizations=list(prof.optimizations) if prof else [],
     )
 
     base = f"http://127.0.0.1:{port}/v1"
@@ -985,6 +1116,9 @@ def gateway(
     ttl: float = typer.Option(None, "--ttl"),
     idle: int = typer.Option(20, "--idle", help="Auto-destroy after N idle minutes"),
     context: int = typer.Option(None, "--context"),
+    opt: list[str] = typer.Option(
+        None, "--opt", help="Optimization KEY or KEY=VAL (repeatable); see `aiod opt list`"
+    ),
     port: int = typer.Option(4000, "--port"),
     bind: str = typer.Option("127.0.0.1", "--bind", help="Address to bind (non-loopback enforces auth)"),
     write_ccr: bool = typer.Option(True, "--ccr/--no-ccr", help="Point CCR at the gateway"),
@@ -1017,6 +1151,8 @@ def gateway(
     if was_token_minted(s) and persist_vllm_api_key(s.vllm_api_key):
         console.print("[dim]persisted VLLM_API_KEY to ~/.config/aiod/.env[/]")
 
+    opt_tokens = _opt_tokens(opt, prof)
+    _validate_opts(opt_tokens)
     spin_kwargs = dict(
         model=model,
         quant=quant or (prof.quant if prof else "bf16"),
@@ -1028,6 +1164,7 @@ def gateway(
         concurrency=prof.concurrency if prof else 4,
         tool_parser=prof.tool_call_parser if prof else None,  # None -> model_configs
         extra_args=list(prof.extra_vllm_args) if prof else [],
+        optimizations=opt_tokens,
     )
 
     base = f"http://127.0.0.1:{port}/v1"
@@ -1074,6 +1211,9 @@ def up(
     ttl: float = typer.Option(None, "--ttl"),
     idle: int = typer.Option(20, "--idle", help="Auto-destroy after N idle minutes"),
     context: int = typer.Option(None, "--context"),
+    opt: list[str] = typer.Option(
+        None, "--opt", help="Optimization KEY or KEY=VAL (repeatable); see `aiod opt list`"
+    ),
     port: int = typer.Option(4000, "--port"),
     write_ccr: bool = typer.Option(True, "--ccr/--no-ccr", help="Point CCR at the local gateway"),
     anthropic: bool = typer.Option(
@@ -1107,6 +1247,8 @@ def up(
     if was_token_minted(s) and persist_vllm_api_key(s.vllm_api_key):
         console.print("[dim]persisted VLLM_API_KEY to ~/.config/aiod/.env[/]")
 
+    opt_tokens = _opt_tokens(opt, prof)
+    _validate_opts(opt_tokens)
     spin_kwargs = dict(
         model=model,
         quant=quant or (prof.quant if prof else "bf16"),
@@ -1118,6 +1260,7 @@ def up(
         concurrency=prof.concurrency if prof else 4,
         tool_parser=prof.tool_call_parser if prof else None,  # None -> model_configs
         extra_args=list(prof.extra_vllm_args) if prof else [],
+        optimizations=opt_tokens,
     )
 
     # Wire CCR at the STABLE local gateway URL — never the rotating box — so CCR
@@ -1163,6 +1306,10 @@ def up(
             cmd += ["--ttl", str(spin_kwargs["ttl_hours"])]
         if spin_kwargs["context"] is not None:
             cmd += ["--context", str(spin_kwargs["context"])]
+        # Forward each opt token as a real --opt flag (a detached gateway would
+        # otherwise silently drop opts not carried by the profile).
+        for tok in spin_kwargs["optimizations"]:
+            cmd += ["--opt", tok]
         if anthropic:
             cmd += ["--anthropic"]
         if not no_spin:

--- a/aiod/engine.py
+++ b/aiod/engine.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 import time
 
 from . import events, model_configs, providers, state
+from . import optimizations as opts_mod
 from .bootstrap import CONTAINER_PORT, ServerConfig
 from .config import Settings
 from .health import wait_until_ready
@@ -28,6 +29,7 @@ def launch(
     concurrency: int = 4,
     tool_parser: str | None = None,  # None -> resolve from model_configs
     extra_args: list[str] | None = None,
+    optimizations: list[str] | None = None,  # opt selection tokens (KEY or KEY=VAL)
     on_event=None,
 ) -> state.Instance | None:
     """Size → find cheapest fit → rent → wait for boot + model load. Saves state
@@ -41,11 +43,16 @@ def launch(
     max_p = max_price if max_price is not None else s.max_price
     ttl_h = ttl_hours if ttl_hours is not None else s.ttl_hours
 
+    # Parse opts ONCE; the SAME resolved keys+values feed sizing (cheaper tier)
+    # and the ServerConfig argv below — so the two paths can't disagree.
+    opt_keys, opt_vals = opts_mod.parse_selection(optimizations or [])
+
     events.clear()
     emit("sizing", model)
     try:
         sizing = size_model(
-            model, hf_token=s.hf_token, quants=[quant], context_len=context, concurrency=concurrency
+            model, hf_token=s.hf_token, quants=[quant], context_len=context,
+            concurrency=concurrency, opts=opt_keys, opt_values=opt_vals,
         )
     except Exception as e:  # noqa: BLE001 - background task; report and bail
         emit("error", f"sizing failed: {e}")
@@ -78,6 +85,8 @@ def launch(
                 max_model_len=context,
                 tool_call_parser=tool_parser or mc.tool_call_parser,
                 extra_args=(extra_args or []) + mc.vllm_serving_args(),
+                optimizations=opt_keys,
+                opt_values=opt_vals,
                 hf_token=s.hf_token,
             )
             emit("renting", f"{offer.desc} @ ${offer.dph_total:.2f}/hr")

--- a/aiod/optimizations.py
+++ b/aiod/optimizations.py
@@ -1,0 +1,418 @@
+"""Pluggable serving/sizing optimizations.
+
+An *optimization* is a named toggle (optionally value-bearing) that can do up to
+three things, each on its own seam:
+
+  (a) append vLLM / llama.cpp **serving flags** (just before ``extra_args``, so
+      ``extra_args`` still wins) — see :meth:`Optimization.vllm_args` /
+      :meth:`Optimization.llamacpp_args`;
+  (b) scale the **VRAM sizing** estimate via multiplicative
+      :class:`SizingKnobs` applied inside ``sizing.estimate_vram`` before GPU
+      selection — see :meth:`Optimization.sizing`;
+  (c) raise a **hardware floor** (compute-capability) via
+      :class:`OptRequirements`, stamped onto the ``QuantPlan`` and folded into
+      the vast offer search.
+
+ONE source of truth: :func:`resolve` produces a single :class:`ResolvedOpts`
+whose ``keys`` drive BOTH the serving argv (``ServerConfig.optimizations``) and
+the sizing path (``estimate_vram`` knobs). Applicability is decided by
+:meth:`Optimization.applies`, which — by contract — may read ONLY
+``engine``/``quant``/``repo_id``/``value``/``draft_model`` from the context and
+NEVER ``spec``. ``spec`` is populated only on the sizing path and may be read
+only by :meth:`Optimization.sizing`. That contract is what closes the
+serving(spec=None) vs sizing(spec=set) split-brain: ``applies`` returns the same
+answer on both paths, so the same key set feeds argv and sizing.
+
+Registry layering mirrors ``model_configs``/``profiles`` ("later wins"):
+built-in  <  entry-point plugin (group ``aiod.optimizations``). Built-ins all
+ship ``default_on=False`` so the no-opt path is byte-identical to before.
+"""
+
+from __future__ import annotations
+
+import sys
+from dataclasses import dataclass, field, replace
+from typing import TYPE_CHECKING, Protocol, runtime_checkable
+
+if TYPE_CHECKING:
+    from .sizing import ModelSpec
+
+# importlib.metadata entry-point group third-party plugins register under.
+ENTRYPOINT_GROUP = "aiod.optimizations"
+
+
+# --------------------------------------------------------------------------- #
+# Data types
+# --------------------------------------------------------------------------- #
+
+@dataclass(frozen=True)
+class OptContext:
+    """Everything an optimization may inspect.
+
+    CONTRACT: ``applies``/``vllm_args``/``llamacpp_args`` may read
+    ``engine``/``quant``/``repo_id``/``value``/``draft_model`` only. ``spec`` is
+    populated ONLY on the sizing path and may be read ONLY by ``sizing``. This
+    forbids spec-dependent applicability, which is what closes the
+    serving(spec=None) vs sizing(spec=set) split-brain.
+    """
+
+    engine: str
+    quant: str
+    repo_id: str
+    concurrency: int = 4
+    spec: ModelSpec | None = None
+    value: str | None = None
+    draft_model: str | None = None
+
+
+@dataclass
+class SizingKnobs:
+    """Multiplicative VRAM scalers (order-independent; defaults == today)."""
+
+    kv_scale: float = 1.0
+    weight_scale: float = 1.0
+
+
+@dataclass(frozen=True)
+class OptRequirements:
+    """Hardware/runtime needs an optimization imposes."""
+
+    min_compute_cap: int = 0
+    needs_draft_model: bool = False
+
+
+@runtime_checkable
+class Optimization(Protocol):
+    key: str
+    summary: str
+    tradeoff: str
+    engines: tuple[str, ...]
+    default_on: bool
+    takes_value: bool
+    conflicts_with: tuple[str, ...]
+    provides: tuple[str, ...]
+
+    def applies(self, ctx: OptContext) -> bool: ...
+    def requirements(self, ctx: OptContext) -> OptRequirements: ...
+    def vllm_args(self, ctx: OptContext) -> list[str]: ...
+    def llamacpp_args(self, ctx: OptContext) -> list[str]: ...
+    def sizing(self, knobs: SizingKnobs, ctx: OptContext) -> SizingKnobs: ...
+
+
+@dataclass(frozen=True)
+class BaseOpt:
+    """No-op defaults so a plugin overrides only what it touches (mirrors
+    ``ModelConfig``). Subclass and override the seams you actually use."""
+
+    key: str
+    summary: str
+    tradeoff: str
+    engines: tuple[str, ...] = ("vllm",)
+    default_on: bool = False
+    takes_value: bool = False
+    conflicts_with: tuple[str, ...] = ()
+    provides: tuple[str, ...] = ()
+
+    def applies(self, ctx: OptContext) -> bool:
+        return ctx.engine in self.engines
+
+    def requirements(self, ctx: OptContext) -> OptRequirements:
+        return OptRequirements()
+
+    def vllm_args(self, ctx: OptContext) -> list[str]:
+        return []
+
+    def llamacpp_args(self, ctx: OptContext) -> list[str]:
+        return []
+
+    def sizing(self, knobs: SizingKnobs, ctx: OptContext) -> SizingKnobs:
+        return knobs
+
+
+@dataclass
+class ResolvedOpts:
+    """The single source of truth threaded to BOTH serving argv and sizing."""
+
+    keys: list[str]
+    knobs: SizingKnobs
+    requirements: OptRequirements
+    skipped: list[tuple[str, str]] = field(default_factory=list)
+
+
+# --------------------------------------------------------------------------- #
+# Built-in optimizations
+# --------------------------------------------------------------------------- #
+
+class _PrefixCaching(BaseOpt):
+    def vllm_args(self, ctx: OptContext) -> list[str]:
+        return ["--enable-prefix-caching"]
+
+
+class _ChunkedPrefill(BaseOpt):
+    def vllm_args(self, ctx: OptContext) -> list[str]:
+        args = ["--enable-chunked-prefill"]
+        if ctx.value:
+            args += ["--max-num-batched-tokens", str(ctx.value)]
+        return args
+
+
+class _KvCacheFp8(BaseOpt):
+    def vllm_args(self, ctx: OptContext) -> list[str]:
+        return ["--kv-cache-dtype", "fp8"]
+
+    def requirements(self, ctx: OptContext) -> OptRequirements:
+        # fp8 KV is only reliable on Ada+ (cc 8.9), same floor as fp8 weights.
+        return OptRequirements(min_compute_cap=890)
+
+    def sizing(self, knobs: SizingKnobs, ctx: OptContext) -> SizingKnobs:
+        # Scale the OUTPUT kv_gb (not KV_BYTES) so it also halves the
+        # config-less weights*0.15 fallback branch in estimate_vram.
+        return replace(knobs, kv_scale=knobs.kv_scale * 0.5)
+
+
+class _MaxNumSeqs(BaseOpt):
+    def vllm_args(self, ctx: OptContext) -> list[str]:
+        return ["--max-num-seqs", str(ctx.value or 256)]
+
+    def sizing(self, knobs: SizingKnobs, ctx: OptContext) -> SizingKnobs:
+        # Raise the KV estimate to match the higher concurrent-seq cap so the
+        # sizer picks a bigger GPU instead of OOMing at runtime (never the
+        # OOM direction).
+        n = int(ctx.value or 256)
+        factor = max(1.0, n / max(1, ctx.concurrency))
+        return replace(knobs, kv_scale=knobs.kv_scale * factor)
+
+
+class _SpeculativeDecoding(BaseOpt):
+    def applies(self, ctx: OptContext) -> bool:
+        # Inert until a draft model is supplied (real impl is future work).
+        return ctx.engine in self.engines and ctx.draft_model is not None
+
+    def requirements(self, ctx: OptContext) -> OptRequirements:
+        return OptRequirements(needs_draft_model=True)
+
+    def vllm_args(self, ctx: OptContext) -> list[str]:
+        if not ctx.draft_model:
+            return []
+        return ["--speculative-config", f'{{"model": "{ctx.draft_model}"}}']
+
+
+_BUILTINS: list[Optimization] = [
+    _KvCacheFp8(
+        key="kv-cache-fp8",
+        summary="FP8 KV cache (~half the KV-cache VRAM)",
+        tradeoff="Tiny accuracy cost; needs Ada+ (compute cap 8.9).",
+        engines=("vllm",),
+        provides=("kv-dtype",),
+    ),
+    _PrefixCaching(
+        key="prefix-caching",
+        summary="Reuse shared prompt prefixes across requests (APC)",
+        tradeoff="None; recent vLLM already enables it — forces it on pinned images.",
+        engines=("vllm",),
+    ),
+    _ChunkedPrefill(
+        key="chunked-prefill",
+        summary="Chunk long prefills for steadier latency",
+        tradeoff="Marginal throughput trade for smoother TTFT.",
+        engines=("vllm",),
+        takes_value=True,
+    ),
+    _MaxNumSeqs(
+        key="max-num-seqs",
+        summary="Raise the concurrent-sequence cap (default 256)",
+        tradeoff="More KV VRAM; the sizer grows the estimate to match.",
+        engines=("vllm",),
+        takes_value=True,
+    ),
+    _SpeculativeDecoding(
+        key="speculative-decoding",
+        summary="Speculative decoding (requires draft model)",
+        tradeoff="Faster decode; needs a draft model (inert today).",
+        engines=("vllm",),
+        takes_value=True,
+    ),
+]
+
+_BUILTIN_KEYS = {o.key for o in _BUILTINS}
+
+
+# --------------------------------------------------------------------------- #
+# Registry + entry-point loading
+# --------------------------------------------------------------------------- #
+
+def _iter_entry_points():
+    """List entry points in our group (isolated so tests can monkeypatch it)."""
+    from importlib.metadata import entry_points
+
+    return list(entry_points(group=ENTRYPOINT_GROUP))
+
+
+def _load_entrypoints() -> list[Optimization]:
+    """Load plugin optimizations. Fail-SOFT but NOT silent: a broken plugin is
+    skipped with a one-line stderr warning so a launch never breaks yet bugs are
+    visible."""
+    out: list[Optimization] = []
+    try:
+        eps = _iter_entry_points()
+    except Exception as e:  # noqa: BLE001 - never let plugin discovery break a launch
+        print(f"aiod: warning: could not enumerate optimization plugins: {e}", file=sys.stderr)
+        return out
+    for ep in eps:
+        try:
+            obj = ep.load()
+            opt = obj() if isinstance(obj, type) else obj
+            if not hasattr(opt, "key"):
+                raise TypeError("loaded object is not an Optimization (no .key attribute)")
+            out.append(opt)
+        except Exception as e:  # noqa: BLE001 - fail-soft per plugin, but warn
+            name = getattr(ep, "name", "?")
+            print(
+                f"aiod: warning: skipping optimization plugin '{name}': {e}",
+                file=sys.stderr,
+            )
+    return out
+
+
+def registry() -> dict[str, Optimization]:
+    """Built-ins then entry-points, keyed by ``opt.key`` (later wins)."""
+    reg: dict[str, Optimization] = {o.key: o for o in _BUILTINS}
+    for o in _load_entrypoints():
+        if o.key in _BUILTIN_KEYS:
+            print(
+                f"aiod: warning: plugin overrides built-in optimization '{o.key}' "
+                f"(core keys are reserved)",
+                file=sys.stderr,
+            )
+        reg[o.key] = o
+    return reg
+
+
+def enumerate_all() -> list[Optimization]:
+    return list(registry().values())
+
+
+def get(key: str) -> Optimization | None:
+    return registry().get(key)
+
+
+def default_selection() -> list[str]:
+    return [o.key for o in enumerate_all() if o.default_on]
+
+
+# --------------------------------------------------------------------------- #
+# Selection parsing + resolution
+# --------------------------------------------------------------------------- #
+
+def parse_selection(tokens: list[str]) -> tuple[list[str], dict[str, str]]:
+    """Split ``['max-num-seqs=256', 'prefix-caching']`` into ordered keys plus a
+    ``{key: value}`` map. Splits on the first ``=`` only."""
+    keys: list[str] = []
+    values: dict[str, str] = {}
+    for tok in tokens:
+        if tok is None:
+            continue
+        if "=" in tok:
+            k, v = tok.split("=", 1)
+        else:
+            k, v = tok, None
+        k = k.strip()
+        if not k:
+            continue
+        keys.append(k)
+        if v is not None:
+            values[k] = v
+    return keys, values
+
+
+def _check_conflicts(chosen: list[Optimization]) -> None:
+    """Raise on a declared ``conflicts_with`` pair or a duplicate ``provides``."""
+    keys = {o.key for o in chosen}
+    provided: dict[str, str] = {}
+    for o in chosen:
+        for c in o.conflicts_with:
+            if c in keys:
+                raise ValueError(f"optimization '{o.key}' conflicts with '{c}'")
+        for p in o.provides:
+            if p in provided:
+                raise ValueError(
+                    f"optimizations '{provided[p]}' and '{o.key}' both provide '{p}'"
+                )
+            provided[p] = o.key
+
+
+def resolve(selected: list[str], values: dict[str, str], ctx: OptContext) -> ResolvedOpts:
+    """Fold the selected opts (in REGISTRY order) into one ResolvedOpts.
+
+    Validates value usage and conflicts/provides, applies the ``applies`` gate
+    (recording skipped (key, reason)), multiplies the sizing knobs, and takes the
+    max over ``min_compute_cap``.
+    """
+    reg = registry()
+    values = values or {}
+    skipped: list[tuple[str, str]] = []
+
+    # Reject a value on a toggle-only opt (value-form ambiguity guard).
+    for k, _v in values.items():
+        opt = reg.get(k)
+        if opt is not None and not opt.takes_value:
+            raise ValueError(f"optimization '{k}' does not take a value")
+
+    selected_set = set(selected)
+    for k in selected:
+        if k not in reg:
+            skipped.append((k, "unknown"))
+
+    # REGISTRY order (not selection order) => reproducible argv & sizing.
+    ordered = [reg[k] for k in reg if k in selected_set]
+    _check_conflicts(ordered)
+
+    keys: list[str] = []
+    knobs = SizingKnobs()
+    min_cc = 0
+    needs_draft = False
+    for opt in ordered:
+        octx = replace(ctx, value=values.get(opt.key))
+        if not opt.applies(octx):
+            skipped.append((opt.key, "not applicable"))
+            continue
+        keys.append(opt.key)
+        knobs = opt.sizing(knobs, octx)
+        req = opt.requirements(octx)
+        min_cc = max(min_cc, req.min_compute_cap)
+        needs_draft = needs_draft or req.needs_draft_model
+
+    return ResolvedOpts(
+        keys=keys,
+        knobs=knobs,
+        requirements=OptRequirements(min_compute_cap=min_cc, needs_draft_model=needs_draft),
+        skipped=skipped,
+    )
+
+
+def _engine_flags(
+    keys: list[str], values: dict[str, str], ctx: OptContext, *, engine: str
+) -> list[str]:
+    reg = registry()
+    values = values or {}
+    selected = set(keys)
+    out: list[str] = []
+    for k in reg:  # REGISTRY order for reproducible argv
+        if k not in selected:
+            continue
+        opt = reg[k]
+        octx = replace(ctx, value=values.get(k))
+        if not opt.applies(octx):
+            continue
+        out += opt.vllm_args(octx) if engine == "vllm" else opt.llamacpp_args(octx)
+    return out
+
+
+def vllm_flags(keys: list[str], values: dict[str, str], ctx: OptContext) -> list[str]:
+    """Emit vLLM flags for ``keys`` in REGISTRY order (gated by ``applies``)."""
+    return _engine_flags(keys, values, ctx, engine="vllm")
+
+
+def llamacpp_flags(keys: list[str], values: dict[str, str], ctx: OptContext) -> list[str]:
+    """Emit llama.cpp flags for ``keys`` in REGISTRY order (gated by ``applies``)."""
+    return _engine_flags(keys, values, ctx, engine="llamacpp")

--- a/aiod/profiles.py
+++ b/aiod/profiles.py
@@ -34,6 +34,7 @@ class Profile:
     idle_minutes: int | None = None  # auto-shutdown after this idle window
     tool_call_parser: str | None = None  # vLLM --tool-call-parser; None = use model_configs
     extra_vllm_args: list[str] = field(default_factory=list)
+    optimizations: list[str] = field(default_factory=list)  # opt selection tokens (KEY or KEY=VAL)
     description: str = ""
 
     @classmethod

--- a/aiod/sizing.py
+++ b/aiod/sizing.py
@@ -20,6 +20,9 @@ from urllib.parse import urlparse
 
 import httpx
 
+from . import optimizations
+from .optimizations import SizingKnobs  # noqa: F401 - re-exported for type hints
+
 HF_API = "https://huggingface.co/api/models"
 HF_RESOLVE = "https://huggingface.co/{repo}/resolve/main/config.json"
 
@@ -122,6 +125,10 @@ class QuantPlan:
     kv_gb: float
     required_vram_gb: float
     options: list[GpuOption]
+    # Hardware floor for the offer search (Ampere by default; opts can raise it).
+    min_compute_cap: int = 800
+    # Resolved optimization keys folded into this plan's sizing.
+    applied_opts: list[str] = field(default_factory=list)
 
     @property
     def cheapest_fit(self) -> GpuOption | None:
@@ -242,10 +249,19 @@ def estimate_vram(
     spec: ModelSpec,
     quant: str,
     context_tokens: int,
+    knobs: SizingKnobs | None = None,
 ) -> tuple[float, float, float]:
-    """Return (weights_gb, kv_gb, required_total_gb) for a quant scheme."""
+    """Return (weights_gb, kv_gb, required_total_gb) for a quant scheme.
+
+    ``knobs`` (from the optimization layer) multiplicatively scales the weights
+    and KV result BEFORE the required sum, so a smaller/larger required flows
+    into plan_gpus and auto-selects a different tier. ``knobs=None`` =>
+    float-identical to the un-optimized estimate.
+    """
     bytes_per_param = QUANT_BYTES[quant]
     weights_gb = spec.params * bytes_per_param / 1e9
+    if knobs is not None:
+        weights_gb *= knobs.weight_scale
 
     kv_per_tok = _kv_bytes_per_token(spec)
     if kv_per_tok is not None:
@@ -253,6 +269,9 @@ def estimate_vram(
     else:
         # No config shape available — assume KV ~ 15% of weights as a rough floor.
         kv_gb = weights_gb * 0.15
+    if knobs is not None:
+        # Scale the OUTPUT kv_gb so kv-cache-fp8 also halves the fallback branch.
+        kv_gb *= knobs.kv_scale
 
     required = weights_gb * OVERHEAD_MULT + kv_gb + FIXED_GB_PER_GPU
     return weights_gb, kv_gb, required
@@ -296,8 +315,16 @@ def size_model(
     context_len: int | None = None,
     concurrency: int = 4,
     max_context_for_estimate: int = 32768,
+    opts: list[str] | None = None,
+    opt_values: dict[str, str] | None = None,
 ) -> SizingResult:
-    """End-to-end: HF link -> sizing across quant options."""
+    """End-to-end: HF link -> sizing across quant options.
+
+    ``opts``/``opt_values`` are resolved per quant (via the optimization layer),
+    scaling the VRAM estimate and stamping the compute-cap floor + applied keys
+    onto each QuantPlan — in ONE place, so size_any and engine.launch can never
+    ship the sizing shrink without its hardware gate (no split-brain).
+    """
     spec = fetch_model_spec(model, hf_token=hf_token)
 
     ctx = context_len or spec.max_context or 8192
@@ -307,7 +334,19 @@ def size_model(
     quants = quants or ["bf16", "fp8", "awq-int4"]
     plans: list[QuantPlan] = []
     for q in quants:
-        weights_gb, kv_gb, required = estimate_vram(spec, q, context_tokens)
+        knobs = None
+        min_cc = 800
+        applied: list[str] = []
+        if opts:
+            octx = optimizations.OptContext(
+                engine="vllm", quant=q, repo_id=spec.repo_id,
+                concurrency=max(1, concurrency), spec=spec,
+            )
+            resolved = optimizations.resolve(opts, opt_values or {}, octx)
+            knobs = resolved.knobs
+            min_cc = max(800, resolved.requirements.min_compute_cap)
+            applied = resolved.keys
+        weights_gb, kv_gb, required = estimate_vram(spec, q, context_tokens, knobs=knobs)
         plans.append(
             QuantPlan(
                 quant=q,
@@ -316,6 +355,8 @@ def size_model(
                 kv_gb=kv_gb,
                 required_vram_gb=required,
                 options=plan_gpus(required),
+                min_compute_cap=min_cc,
+                applied_opts=applied,
             )
         )
 
@@ -451,6 +492,8 @@ def size_any(
     quants: list[str] | None = None,
     context_len: int | None = None,
     concurrency: int = 4,
+    opts: list[str] | None = None,
+    opt_values: dict[str, str] | None = None,
 ) -> SizingResult:
     """Engine-aware entry point: auto-detect GGUF vs safetensors (or force via
     `engine`) and return the matching SizingResult."""
@@ -461,5 +504,6 @@ def size_any(
     if eng == "llamacpp":
         return size_gguf_model(repo, hf_token=hf_token, context_len=context_len)
     return size_model(
-        repo, hf_token=hf_token, quants=quants, context_len=context_len, concurrency=concurrency
+        repo, hf_token=hf_token, quants=quants, context_len=context_len,
+        concurrency=concurrency, opts=opts, opt_values=opt_values,
     )

--- a/aiod/vast.py
+++ b/aiod/vast.py
@@ -300,7 +300,9 @@ class VastClient:
         Bounded to `max_candidates` searches to stay under vast.ai's rate limit
         (the client also throttles + backs off on 429)."""
         # fp8 is only reliable on Ada+ (cc 8.9); on Ampere it yields garbage output.
-        min_cc = 890 if plan.quant == "fp8" else 800
+        # plan.min_compute_cap (default 800) lifts the floor for opts like
+        # kv-cache-fp8 that also require Ada+; max() keeps every existing path a no-op.
+        min_cc = max(890 if plan.quant == "fp8" else 800, plan.min_compute_cap)
         # Scale the network-speed floor to the download size so big GGUF models don't
         # land on a slow node (343GB @ 200Mbps = ~3.8h of idle GPU billing).
         if plan.weights_gb > 150:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,6 +26,14 @@ dev = ["ruff>=0.6", "pytest>=8.0"]
 [project.scripts]
 aiod = "aiod.cli:app"
 
+# Third-party optimization plugins register an Optimization (class or instance)
+# under the 'aiod.optimizations' entry-point group; aiod discovers them
+# fail-soft at runtime (importlib.metadata is stdlib — no new dependency). Core
+# built-in keys are reserved (a later-wins override emits a stderr warning).
+# Declare one in YOUR plugin's pyproject.toml like:
+#   [project.entry-points."aiod.optimizations"]
+#   my-opt = "my_pkg.module:MyOptimization"
+
 [project.urls]
 Homepage = "https://github.com/jhammant/AIonDemandCluster"
 Repository = "https://github.com/jhammant/AIonDemandCluster"

--- a/tests/test_optimizations.py
+++ b/tests/test_optimizations.py
@@ -1,0 +1,505 @@
+"""Tests for the pluggable optimization layer (interface, serving wire, sizing
+hook, hardware gate, CLI/profile wiring) including the load-bearing invariants."""
+
+from types import SimpleNamespace
+
+import pytest
+from typer.testing import CliRunner
+
+from aiod import optimizations as opt
+from aiod import profiles
+from aiod.bootstrap import ServerConfig
+from aiod.optimizations import (
+    BaseOpt,
+    OptContext,
+    SizingKnobs,
+    _check_conflicts,
+    parse_selection,
+    resolve,
+    vllm_flags,
+)
+from aiod.profiles import Profile
+from aiod.sizing import ModelSpec, QuantPlan, estimate_vram, plan_gpus, size_model
+
+runner = CliRunner()
+
+
+# --------------------------------------------------------------------------- #
+# Fixtures / helpers
+# --------------------------------------------------------------------------- #
+
+def _spec(params: int, **kw) -> ModelSpec:
+    base = dict(
+        repo_id="test/model",
+        params=params,
+        dtype="BF16",
+        num_layers=80,
+        hidden_size=8192,
+        num_attention_heads=64,
+        num_kv_heads=8,
+        max_context=8192,
+        architecture="llama",
+        gated=False,
+        params_source="safetensors",
+    )
+    base.update(kw)
+    return ModelSpec(**base)
+
+
+def _cfg(**kw) -> ServerConfig:
+    base = dict(repo_id="org/model", num_gpus=2, quant="bf16", api_key="sk-tok")
+    base.update(kw)
+    return ServerConfig(**base)
+
+
+# Golden argv with NO optimizations (the pre-change output). Byte-identity here
+# is the back-compat invariant: an empty opt list must not perturb a single byte.
+_VLLM_GOLDEN = [
+    "--host", "0.0.0.0",
+    "--port", "8000",
+    "--model", "org/model",
+    "--served-model-name", "org/model",
+    "--api-key", "sk-tok",
+    "--tensor-parallel-size", "2",
+    "--gpu-memory-utilization", "0.92",
+    "--enable-auto-tool-choice",
+    "--tool-call-parser", "hermes",
+]
+_LLAMACPP_GOLDEN = [
+    "-hf", "org/m-GGUF:Q4_K_M",
+    "--host", "0.0.0.0",
+    "--port", "8000",
+    "--api-key", "sk-tok",
+    "-ngl", "999",
+    "--jinja",
+    "-c", "32768",
+]
+
+
+# --------------------------------------------------------------------------- #
+# Byte-identity / back-compat
+# --------------------------------------------------------------------------- #
+
+def test_vllm_args_empty_opts_byte_identical():
+    assert _cfg().server_args() == _VLLM_GOLDEN
+    assert _cfg(optimizations=[]).server_args() == _VLLM_GOLDEN
+
+
+def test_llamacpp_args_empty_opts_byte_identical():
+    cfg = _cfg(engine="llamacpp", gguf_quant="Q4_K_M", repo_id="org/m-GGUF")
+    assert cfg.server_args() == _LLAMACPP_GOLDEN
+    cfg2 = _cfg(engine="llamacpp", gguf_quant="Q4_K_M", repo_id="org/m-GGUF", optimizations=[])
+    assert cfg2.server_args() == _LLAMACPP_GOLDEN
+
+
+def test_default_selection_is_empty():
+    # All built-ins ship default_on=False -> the no-opt path is trivially proven.
+    assert opt.default_selection() == []
+
+
+# --------------------------------------------------------------------------- #
+# Serving flag emission
+# --------------------------------------------------------------------------- #
+
+def test_prefix_caching_appends_exactly_one_flag_vllm():
+    args = _cfg(optimizations=["prefix-caching"]).server_args()
+    assert args == _VLLM_GOLDEN + ["--enable-prefix-caching"]
+
+
+def test_prefix_caching_is_noop_on_llamacpp():
+    cfg = _cfg(engine="llamacpp", gguf_quant="Q4_K_M", repo_id="org/m-GGUF",
+               optimizations=["prefix-caching"])
+    # engine != vllm => applies() False => no flag, argv byte-identical.
+    assert cfg.server_args() == _LLAMACPP_GOLDEN
+
+
+def test_registry_order_argv_reproducible():
+    a = _cfg(optimizations=["prefix-caching", "kv-cache-fp8"]).server_args()
+    b = _cfg(optimizations=["kv-cache-fp8", "prefix-caching"]).server_args()
+    assert a == b
+    # kv-cache-fp8 precedes prefix-caching in the registry, so that's the order.
+    assert a == _VLLM_GOLDEN + ["--kv-cache-dtype", "fp8", "--enable-prefix-caching"]
+
+
+def test_extra_args_still_last_after_opt_flags():
+    args = _cfg(optimizations=["prefix-caching"], extra_args=["--seed", "1"]).server_args()
+    assert args[-2:] == ["--seed", "1"]
+    assert args.index("--enable-prefix-caching") < args.index("--seed")
+
+
+def test_chunked_prefill_value_form():
+    args = _cfg(optimizations=["chunked-prefill"],
+               opt_values={"chunked-prefill": "2048"}).server_args()
+    assert args[-3:] == ["--enable-chunked-prefill", "--max-num-batched-tokens", "2048"]
+
+
+def test_max_num_seqs_flag_uses_value_or_default():
+    a = _cfg(optimizations=["max-num-seqs"]).server_args()
+    assert a[-2:] == ["--max-num-seqs", "256"]
+    b = _cfg(optimizations=["max-num-seqs"], opt_values={"max-num-seqs": "512"}).server_args()
+    assert b[-2:] == ["--max-num-seqs", "512"]
+
+
+# --------------------------------------------------------------------------- #
+# parse_selection / resolve / conflicts
+# --------------------------------------------------------------------------- #
+
+def test_parse_selection_splits_keys_and_values():
+    keys, values = parse_selection(["max-num-seqs=256", "prefix-caching"])
+    assert keys == ["max-num-seqs", "prefix-caching"]
+    assert values == {"max-num-seqs": "256"}
+
+
+def test_resolve_rejects_value_on_toggle_only_opt():
+    ctx = OptContext(engine="vllm", quant="bf16", repo_id="org/m")
+    with pytest.raises(ValueError):
+        resolve(["prefix-caching"], {"prefix-caching": "x"}, ctx)
+
+
+def test_resolve_records_unknown_as_skipped():
+    ctx = OptContext(engine="vllm", quant="bf16", repo_id="org/m")
+    r = resolve(["bogus"], {}, ctx)
+    assert ("bogus", "unknown") in r.skipped
+    assert r.keys == []
+
+
+def test_check_conflicts_duplicate_provides():
+    a = BaseOpt(key="a", summary="", tradeoff="", provides=("x",))
+    b = BaseOpt(key="b", summary="", tradeoff="", provides=("x",))
+    with pytest.raises(ValueError):
+        _check_conflicts([a, b])
+
+
+def test_check_conflicts_conflicts_with():
+    a = BaseOpt(key="a", summary="", tradeoff="")
+    c = BaseOpt(key="c", summary="", tradeoff="", conflicts_with=("a",))
+    with pytest.raises(ValueError):
+        _check_conflicts([a, c])
+
+
+# --------------------------------------------------------------------------- #
+# Entry-point loading (fail-soft + warn, later-wins override)
+# --------------------------------------------------------------------------- #
+
+class _BadEP:
+    name = "broken-plugin"
+
+    def load(self):
+        raise RuntimeError("boom")
+
+
+class _GoodEP:
+    name = "override-plugin"
+
+    def load(self):
+        return BaseOpt(key="kv-cache-fp8", summary="overridden", tradeoff="")
+
+
+def test_entrypoint_failure_is_skipped_and_warns(monkeypatch, capsys):
+    monkeypatch.setattr(opt, "_iter_entry_points", lambda: [_BadEP()])
+    reg = opt.registry()
+    # Built-ins still resolve despite the broken plugin.
+    assert "kv-cache-fp8" in reg and "prefix-caching" in reg
+    err = capsys.readouterr().err
+    assert "broken-plugin" in err and "skipping" in err.lower()
+
+
+def test_plugin_overrides_builtin_later_wins(monkeypatch, capsys):
+    monkeypatch.setattr(opt, "_iter_entry_points", lambda: [_GoodEP()])
+    reg = opt.registry()
+    assert reg["kv-cache-fp8"].summary == "overridden"
+    err = capsys.readouterr().err
+    assert "overrides built-in" in err
+
+
+# --------------------------------------------------------------------------- #
+# Sizing: float-identity, kv halving, growth, order independence
+# --------------------------------------------------------------------------- #
+
+def test_estimate_vram_knobs_none_float_identical():
+    for params in (7_000_000_000, 32_000_000_000, 70_000_000_000):
+        spec = _spec(params)
+        assert estimate_vram(spec, "bf16", 8192) == estimate_vram(spec, "bf16", 8192, knobs=None)
+
+
+def test_estimate_vram_knobs_none_float_identical_fallback_path():
+    # No config shape -> the weights*0.15 fallback branch.
+    spec = _spec(7_000_000_000, num_layers=None, hidden_size=None, num_attention_heads=None)
+    assert estimate_vram(spec, "bf16", 8192) == estimate_vram(spec, "bf16", 8192, knobs=None)
+
+
+def test_kv_cache_fp8_halves_kv_shaped_path():
+    spec = _spec(70_000_000_000)
+    _, kv0, _ = estimate_vram(spec, "bf16", 100_000)
+    knobs = opt.get("kv-cache-fp8").sizing(SizingKnobs(), OptContext("vllm", "bf16", "org/m"))
+    _, kv1, _ = estimate_vram(spec, "bf16", 100_000, knobs=knobs)
+    assert kv1 == pytest.approx(kv0 * 0.5)
+
+
+def test_kv_cache_fp8_halves_kv_fallback_path():
+    # Config-less: kv = weights*0.15, and kv-cache-fp8 scales the OUTPUT.
+    spec = _spec(7_000_000_000, num_layers=None, hidden_size=None, num_attention_heads=None)
+    _, kv0, _ = estimate_vram(spec, "bf16", 8192)
+    knobs = opt.get("kv-cache-fp8").sizing(SizingKnobs(), OptContext("vllm", "bf16", "org/m"))
+    _, kv1, _ = estimate_vram(spec, "bf16", 8192, knobs=knobs)
+    assert kv1 == pytest.approx(kv0 * 0.5)
+    # weights unchanged (weight_scale stays 1.0).
+    w0, _, _ = estimate_vram(spec, "bf16", 8192)
+    w1, _, _ = estimate_vram(spec, "bf16", 8192, knobs=knobs)
+    assert w1 == w0
+
+
+def test_max_num_seqs_grows_kv_and_is_noop_at_concurrency():
+    spec = _spec(7_000_000_000)
+    o = opt.get("max-num-seqs")
+    # value=256, concurrency=4 -> factor 64.
+    ctx = OptContext("vllm", "bf16", "org/m", concurrency=4, value="256")
+    knobs = o.sizing(SizingKnobs(), ctx)
+    _, kv0, _ = estimate_vram(spec, "bf16", 8192)
+    _, kv1, _ = estimate_vram(spec, "bf16", 8192, knobs=knobs)
+    assert kv1 == pytest.approx(kv0 * 64)
+    # value==concurrency -> no-op.
+    ctx2 = OptContext("vllm", "bf16", "org/m", concurrency=4, value="4")
+    assert o.sizing(SizingKnobs(), ctx2).kv_scale == 1.0
+
+
+def test_kv_scale_order_independent():
+    ctx = OptContext("vllm", "bf16", "org/m", concurrency=4, value="256")
+    fp8 = opt.get("kv-cache-fp8")
+    mns = opt.get("max-num-seqs")
+    forward = mns.sizing(fp8.sizing(SizingKnobs(), ctx), ctx)
+    reverse = fp8.sizing(mns.sizing(SizingKnobs(), ctx), ctx)
+    assert forward.kv_scale == pytest.approx(reverse.kv_scale)
+
+
+# --------------------------------------------------------------------------- #
+# Sizing end-to-end: tier flip + compute-cap stamp (size_model)
+# --------------------------------------------------------------------------- #
+
+def _patch_spec(monkeypatch, spec):
+    monkeypatch.setattr("aiod.sizing.fetch_model_spec", lambda *a, **k: spec)
+
+
+def test_kv_cache_fp8_flips_tier_and_sets_min_cc(monkeypatch):
+    # A KV-heavy 7B at high concurrency lands on a bigger tier at baseline; the
+    # fp8 KV shrink drops it to a cheaper tier.
+    spec = _spec(7_000_000_000)
+    _patch_spec(monkeypatch, spec)
+
+    base = size_model("test/model", quants=["bf16"], context_len=8192, concurrency=12).plan("bf16")
+    optimized = size_model(
+        "test/model", quants=["bf16"], context_len=8192, concurrency=12,
+        opts=["kv-cache-fp8"], opt_values={},
+    ).plan("bf16")
+
+    # required shrinks
+    assert optimized.required_vram_gb < base.required_vram_gb
+    # tier flips to something cheaper (different tier name)
+    assert base.cheapest_fit.tier.name != optimized.cheapest_fit.tier.name
+    # hardware floor stamped + applied keys recorded
+    assert optimized.min_compute_cap == 890
+    assert optimized.applied_opts == ["kv-cache-fp8"]
+    # baseline untouched
+    assert base.min_compute_cap == 800
+    assert base.applied_opts == []
+
+
+def test_size_model_no_opts_float_identical(monkeypatch):
+    spec = _spec(32_000_000_000)
+    _patch_spec(monkeypatch, spec)
+    a = size_model("test/model", quants=["bf16", "fp8"], context_len=8192, concurrency=4)
+    b = size_model("test/model", quants=["bf16", "fp8"], context_len=8192, concurrency=4,
+                   opts=None)
+    for pa, pb in zip(a.plans, b.plans, strict=True):
+        assert pa.required_vram_gb == pb.required_vram_gb
+        assert pa.kv_gb == pb.kv_gb
+        assert pa.min_compute_cap == 800
+
+
+# --------------------------------------------------------------------------- #
+# Hardware gate flows into the vast offer search
+# --------------------------------------------------------------------------- #
+
+def _fitting_plan(quant, min_cc) -> QuantPlan:
+    opts = plan_gpus(30.0)  # something small that fits on a single GPU
+    return QuantPlan(
+        quant=quant, label=quant, weights_gb=14.0, kv_gb=2.0,
+        required_vram_gb=30.0, options=opts, min_compute_cap=min_cc,
+    )
+
+
+def test_vast_min_cc_uses_plan_floor(monkeypatch):
+    from aiod.vast import VastClient
+
+    client = VastClient(api_key="x")
+    seen = {}
+
+    def fake_search(**kw):
+        seen["min_compute_cap"] = kw["min_compute_cap"]
+        return []
+
+    monkeypatch.setattr(client, "search_offers", fake_search)
+
+    # bf16 + opt floor 890 -> 890 (kv-cache-fp8 case).
+    client.price_plan(_fitting_plan("bf16", 890), min_disk_gb=40)
+    assert seen["min_compute_cap"] == 890
+
+    # bf16 default floor -> 800 (every existing path unchanged).
+    client.price_plan(_fitting_plan("bf16", 800), min_disk_gb=40)
+    assert seen["min_compute_cap"] == 800
+
+    # fp8 weights still force 890 even with default plan floor.
+    client.price_plan(_fitting_plan("fp8", 800), min_disk_gb=40)
+    assert seen["min_compute_cap"] == 890
+
+
+# --------------------------------------------------------------------------- #
+# Split-brain regression: opt in sizing IFF its flag in argv
+# --------------------------------------------------------------------------- #
+
+def test_split_brain_sizing_keys_match_argv_flags():
+    spec = _spec(7_000_000_000)
+    selection = ["kv-cache-fp8", "speculative-decoding"]  # latter is inert (no draft model)
+
+    # Sizing path: spec is set, applies() ignores it by contract.
+    sizing_ctx = OptContext("vllm", "bf16", "test/model", concurrency=4, spec=spec)
+    resolved = resolve(selection, {}, sizing_ctx)
+
+    # Serving path: spec is None.
+    serving_ctx = OptContext("vllm", "bf16", "test/model")
+    argv = vllm_flags(selection, {}, serving_ctx)
+
+    # kv-cache-fp8 applies on both -> in sizing keys AND its flag is in argv.
+    assert "kv-cache-fp8" in resolved.keys
+    assert "--kv-cache-dtype" in argv
+    # speculative-decoding is inert -> in NEITHER.
+    assert "speculative-decoding" not in resolved.keys
+    assert "--speculative-config" not in argv
+
+
+# --------------------------------------------------------------------------- #
+# Profiles round-trip
+# --------------------------------------------------------------------------- #
+
+def test_profile_optimizations_roundtrip(tmp_path, monkeypatch):
+    pf = tmp_path / "profiles.yaml"
+    monkeypatch.setattr(profiles, "PROFILE_FILE", pf)
+    profiles.save(Profile(name="opt-prof", model="org/m", optimizations=["kv-cache-fp8", "prefix-caching"]))
+    loaded = profiles.all_profiles()["opt-prof"]
+    assert loaded.optimizations == ["kv-cache-fp8", "prefix-caching"]
+
+
+def test_profile_from_dict_defaults_empty():
+    p = Profile.from_dict("x", {"model": "org/m"})
+    assert p.optimizations == []
+
+
+# --------------------------------------------------------------------------- #
+# CLI: opt list, unknown --opt exits, up --detach forwards --opt
+# --------------------------------------------------------------------------- #
+
+def test_opt_list_runs_without_model():
+    from aiod.cli import app
+    result = runner.invoke(app, ["opt", "list"])
+    assert result.exit_code == 0, result.output
+    assert "kv-cache-fp8" in result.output
+    assert "max-num-seqs" in result.output
+
+
+def test_unknown_opt_exits_nonzero_and_lists_valid(monkeypatch):
+    from aiod.cli import app
+    fake_settings = SimpleNamespace(hf_token=None, max_price=6.0)
+    monkeypatch.setattr("aiod.cli.Settings.load", staticmethod(lambda: fake_settings))
+    monkeypatch.setattr("aiod.cli._require_provider_key", lambda s, provider: None)
+    result = runner.invoke(app, ["estimate", "org/repo", "--opt", "no-such-opt"])
+    assert result.exit_code != 0
+    assert "Unknown optimization" in result.output
+    assert "kv-cache-fp8" in result.output  # lists valid keys
+
+
+def test_estimate_opt_shows_baseline_vs_optimized(monkeypatch):
+    from rich.console import Console
+
+    from aiod import providers
+    from aiod.cli import app
+    from aiod.sizing import SizingResult
+
+    # Wide console so the fit cell (tier flip) isn't truncated under CliRunner.
+    monkeypatch.setattr("aiod.cli.console", Console(width=240))
+    fake_settings = SimpleNamespace(hf_token=None, max_price=6.0)
+    monkeypatch.setattr("aiod.cli.Settings.load", staticmethod(lambda: fake_settings))
+    monkeypatch.setattr("aiod.cli._require_provider_key", lambda s, provider: None)
+
+    spec = _spec(7_000_000_000)
+
+    def make_result(required, fit_required):
+        plan = QuantPlan(
+            quant="bf16", label="bf16", weights_gb=14.0, kv_gb=2.0,
+            required_vram_gb=required, options=plan_gpus(fit_required),
+        )
+        return SizingResult(model=spec, context_tokens=8192, plans=[plan])
+
+    baseline = make_result(60.0, 60.0)      # cheapest_fit -> A100 80GB (1x)
+    optimized = make_result(40.0, 40.0)     # cheapest_fit -> RTX 6000 Ada (1x)
+
+    def fake_size_any(*a, **k):
+        return optimized if k.get("opts") else baseline
+
+    monkeypatch.setattr("aiod.cli.size_any", fake_size_any)
+
+    class _FakeClient:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *exc):
+            return False
+
+        def price_plan(self, *a, **k):
+            return []  # no live offers; sizing-tier flip still shown
+
+    monkeypatch.setattr(providers, "get_client", lambda provider, s: _FakeClient())
+
+    result = runner.invoke(
+        app, ["estimate", "org/repo", "-q", "bf16", "--opt", "kv-cache-fp8"],
+        env={"COLUMNS": "240"},
+    )
+    assert result.exit_code == 0, result.output
+    # baseline != optimized required, shown as an arrow
+    assert "60→40 GB" in result.output
+    # flipped tier (A100 -> RTX 6000 Ada) appears in the fit cell
+    assert "A100" in result.output and "6000" in result.output
+
+
+@pytest.fixture
+def up_detach(monkeypatch):
+    """Stub the detached-gateway side effects and capture the child argv."""
+    captured = {}
+    fake_settings = SimpleNamespace(vllm_api_key="sk-aiod-test")
+    monkeypatch.setattr("aiod.cli.Settings.load", staticmethod(lambda: fake_settings))
+    monkeypatch.setattr("aiod.cli._require_provider_key", lambda s, provider: None)
+    monkeypatch.setattr("aiod.cli.was_token_minted", lambda s: False)
+    monkeypatch.setattr(profiles, "get", lambda name: None)
+    monkeypatch.setattr("aiod.cli.ccr.write_config", lambda *a, **k: None)
+    monkeypatch.setattr("aiod.cli._poll_healthz", lambda *a, **k: True)
+
+    def fake_popen(cmd, *a, **k):
+        captured["cmd"] = cmd
+        return SimpleNamespace(pid=1234)
+
+    monkeypatch.setattr("aiod.cli.subprocess.Popen", fake_popen)
+    return captured
+
+
+def test_up_detach_forwards_opt_tokens(up_detach):
+    from aiod.cli import app
+    result = runner.invoke(
+        app, ["up", "org/repo", "--detach", "--opt", "kv-cache-fp8", "--opt", "max-num-seqs=256"]
+    )
+    assert result.exit_code == 0, result.output
+    cmd = up_detach["cmd"]
+    # Each token re-emitted as a real --opt flag.
+    assert "--opt" in cmd
+    assert "kv-cache-fp8" in cmd
+    assert "max-num-seqs=256" in cmd
+    # exactly two --opt occurrences
+    assert cmd.count("--opt") == 2


### PR DESCRIPTION
Designed + implemented + adversarially reviewed via multi-agent workflows; **I reviewed the diff and ran the suite** before pushing. Opening for your review (not auto-merged).

## What this is
An **extensible `Optimization` plugin interface** — the "plug in optimisation" idea. Each optimization can:
- contribute serving flags (`--kv-cache-dtype fp8`, `--enable-prefix-caching`, …),
- **shrink the VRAM estimate so sizing picks a cheaper GPU**,
- gate its own applicability (engine / compute-cap / quant),
- carry a one-line trade-off note.

Built-ins ship, and third parties add more via the **`aiod.optimizations` entry-point group** (`pip install aiod-opt-x`).

## Built-ins (all default-OFF)
| key | effect | gate |
|-----|--------|------|
| `kv-cache-fp8` | `--kv-cache-dtype fp8` + **halves the KV term** so sizing can drop to a cheaper tier | Ada+ (890 compute-cap floor in the offer search) |
| `prefix-caching` | `--enable-prefix-caching` | vLLM |
| `chunked-prefill` | `--enable-chunked-prefill` (+ batched-tokens) | vLLM |
| `max-num-seqs` | `--max-num-seqs N` + **feeds the sizer** (higher concurrency picks a bigger GPU, never OOMs) | vLLM |
| `speculative-decoding` | inert stub (needs a draft model) | future |

## Surface
`aiod spin … --opt kv-cache-fp8 --opt prefix-caching` · `aiod opt list [MODEL]` · `aiod estimate … --opt …` shows **baseline→optimized VRAM + the flipped tier** · `Profile.optimizations`.

## Why it's safe
One `resolve() → ResolvedOpts` is the **single source of truth** for both serving args and sizing (no split-brain). Every new field defaults empty and **all built-ins are default-off**, so **with no `--opt` the serving argv is byte-identical and the VRAM estimate is float-identical** to today — proven by golden tests. Sets up a future `aiod tune` (sweep the registry).

## Tests
32 new (golden byte/float identity, tier-flip, compute-cap floor, registry-order reproducibility, split-brain regression, entry-point fail-soft+warn, profile round-trip). **166 passing, ruff clean.**

## Known nits (follow-ups, non-blocking)
- `aiod estimate --opt` sizes twice (extra HF call) to render baseline-vs-optimized.
- `--opt` on a GGUF/llama.cpp model silently resolves to no flags (built-ins are vLLM-only) — could warn.