### PR TITLE
chore: release v0.4.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "aiondemandcluster"
-version = "0.3.0"
+version = "0.4.0"
 description = "AI on Demand — spin up a HuggingFace model on vast.ai GPUs and drive it from Claude Code via Claude Code Router."
 readme = "README.md"
 requires-python = ">=3.10"


### PR DESCRIPTION
Bumps version 0.3.0 → 0.4.0 to ship the pluggable optimization layer (#9): `--opt` with KV-cache fp8, prefix caching, chunked-prefill, max-num-seqs, and the `aiod.optimizations` plugin entry-point group. Tagging `v0.4.0` after merge triggers the PyPI publish.