### PR TITLE
feat: `aiod tune` — cheapest-per-token benchmark sweep (v0.5.0)

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,6 +165,46 @@ aiod ccr-config    # re-write the CCR config from the tracked instance
 aiod teardown      # destroy the instance and stop billing  ← run this when done
 ```
 
+### Tune — find the cheapest config that meets a latency bar
+
+`aiod tune` rents a box, sweeps it, and prints a leaderboard ranked by **$/1M
+output tokens**, then recommends the cheapest configuration that meets your
+latency bar. By default it does the cheap thing: **one box, one model load, a
+concurrency ladder only** (vLLM batches concurrency for free). Pass `--sweep-opt`
+(or more than one `--quant`) to engage an opt-combo **relaunch** sweep — each
+optimization combo is a fresh model load, so this costs more and is opt-in.
+
+Cost safety is structural:
+
+- **`--max-cost` is required** (a hard $ ceiling for the whole sweep). The only
+  escape is an explicit `--yes-i-know` to run uncapped.
+- **Guaranteed teardown.** The box is destroyed on success, on error, and on
+  Ctrl-C — including the boot window before the handle is bound (emergency
+  teardown reads the single tracked-instance slot). When `aiod tune` returns, you
+  are not being billed.
+- Hard caps (`--max-cost`, `--max-minutes`) are enforced at every boundary, and a
+  bad node that never starts the container is aborted early instead of billing the
+  full boot timeout.
+
+```bash
+# Default: one box, concurrency ladder, recommend the cheapest point under a p95 bar.
+aiod tune Qwen/Qwen2.5-Coder-7B-Instruct -q fp8 --ttft-p95 1.5 --max-cost 0.50
+
+# Plan + cost estimate only — rents nothing ($0).
+aiod tune coder-7b --max-cost 0.50 --dry-run
+
+# Opt-combo sweep (relaunch per combo): two quants x a prefix-caching toggle.
+aiod tune <model> -q bf16 -q fp8 --sweep-opt prefix-caching --max-cost 2.00
+
+# Save the measured winner as a reusable profile, then reproduce it with spin.
+aiod tune coder-7b -q fp8 --ttft-p95 1.5 --max-cost 0.50 --save-profile coder-fast
+aiod spin --profile coder-fast
+```
+
+The leaderboard marks sizing-**projected** rows with `~` (modeled $/hr, tok/s
+assumed unchanged); projected rows are never the recommendation — the winner is
+always a measured `(config, concurrency)` point.
+
 ### Engines — vLLM and llama.cpp (GGUF)
 
 `aiod` auto-detects the model format: **safetensors / AWQ / fp8 → vLLM**, and

--- a/aiod/cli.py
+++ b/aiod/cli.py
@@ -24,6 +24,7 @@ from rich.table import Table
 from . import (
     branding,
     ccr,
+    engine,
     events,
     model_configs,
     onboard,
@@ -31,6 +32,9 @@ from . import (
     profiles,
     providers,
     state,
+)
+from . import (
+    tune as tune_mod,
 )
 from .bootstrap import CONTAINER_PORT, ServerConfig
 from .config import Settings, persist_vllm_api_key, was_token_minted
@@ -1483,6 +1487,462 @@ def bench(
     console.print(table)
     if concurrency == 1:
         console.print("[dim]Tip: re-run with `-c 8` to measure throughput + cheaper $/1M.[/]")
+
+
+# --------------------------------------------------------------------------- #
+# tune  (sweep + ranked $/1M leaderboard + recommendation)
+# --------------------------------------------------------------------------- #
+
+
+def _parse_ladder(spec: str) -> list[int]:
+    """Parse a concurrency ladder like ``'1,4,8,16'`` -> ``[1, 4, 8, 16]``."""
+    out: list[int] = []
+    for part in (spec or "").split(","):
+        part = part.strip()
+        if not part:
+            continue
+        try:
+            v = int(part)
+        except ValueError:
+            continue
+        if v > 0 and v not in out:
+            out.append(v)
+    return out or [1]
+
+
+def _emergency_teardown(s: Settings) -> None:
+    """Final backstop: destroy whatever box the single state slot still tracks,
+    and assert the slot is empty afterward (warn loudly with the id if not)."""
+    inst = state.load()
+    if inst is not None:
+        try:
+            engine.destroy(s, inst)
+        except Exception:  # noqa: BLE001 - a gone box is fine
+            pass
+    leftover = state.load()
+    if leftover is not None:
+        console.print(
+            f"[red]WARNING:[/] instance [bold]{leftover.instance_id}[/] may still be "
+            f"running — run [bold]aiod teardown[/] to be sure billing stopped."
+        )
+        state.clear()
+
+
+def _fmt(v, unit: str = "", nd: int = 2) -> str:
+    return f"{v:.{nd}f}{unit}" if v is not None else "—"
+
+
+def _render_leaderboard(
+    rows: list, projected: list, rec, *, has_bar: bool
+) -> None:
+    """Ranked $/1M table: measured rows then ~projected rows, recommendation bold."""
+    table = Table(title="Tuning leaderboard — ranked by $/1M output tokens")
+    table.add_column("Opt")
+    table.add_column("Quant")
+    table.add_column("GPU")
+    table.add_column("$/hr", justify="right")
+    table.add_column("Conc", justify="right")
+    table.add_column("TTFT50", justify="right")
+    table.add_column("TTFT95", justify="right")
+    table.add_column("Thrpt", justify="right")
+    table.add_column("$/1M", justify="right")
+    table.add_column("SLA")
+
+    rec_row = rec.row
+    combined = list(rows) + list(projected)
+    combined.sort(key=lambda r: r.cost_per_million if r.cost_per_million is not None else float("inf"))
+    for r in combined:
+        opt = " ".join(r.opt_tokens) or "(none)"
+        is_rec = (rec_row is not None) and (r is rec_row)
+        marker = "~" if r.projected else ""
+        cpm = _fmt(r.cost_per_million, "", 3)
+        cpm_cell = f"[bold]{marker}{cpm}[/]" if (is_rec or not r.projected) else f"{marker}{cpm}"
+        sla = "★" if is_rec else ("modeled" if r.projected else "")
+        opt_cell = f"[bold]{opt}[/]" if is_rec else opt
+        table.add_row(
+            opt_cell,
+            r.quant,
+            r.gpu_desc or "—",
+            _fmt(r.price_per_hr, "", 2),
+            str(r.concurrency),
+            _fmt(r.ttft_p50, "s"),
+            _fmt(r.ttft_p95, "s"),
+            _fmt(r.throughput_tok_s, "", 0),
+            cpm_cell,
+            sla,
+        )
+    console.print(table)
+    if projected:
+        console.print(
+            "[dim]~ = modeled (sizing-projected $/hr, tok/s assumed unchanged) — "
+            "never recommended.[/]"
+        )
+
+
+def _save_tuned_profile(
+    name: str,
+    *,
+    repo: str,
+    provider: str,
+    winner,
+    context: int | None,
+    ttl_h: float | None,
+    idle_m: int | None,
+    force: bool,
+) -> None:
+    import datetime
+
+    if profiles.is_builtin(name) and not force:
+        console.print(
+            f"[red]'{name}' is a built-in profile.[/] Use --force to overwrite, or pick another name."
+        )
+        return
+    if profiles.get(name) is not None and not profiles.is_builtin(name):
+        if not typer.confirm(f"Profile '{name}' already exists — overwrite?"):
+            return
+    opt_tokens = [
+        f"{k}={winner.opt_values[k]}" if k in winner.opt_values else k for k in winner.opt_keys
+    ]
+    date = datetime.date.today().isoformat()
+    p95 = f", p95={winner.ttft_p95:.2f}s" if winner.ttft_p95 is not None else ""
+    p = profiles.Profile(
+        name=name,
+        model=repo,
+        provider=provider,
+        quant=winner.quant,
+        max_price=winner.price_per_hr,
+        context=context,
+        concurrency=winner.concurrency,
+        ttl_hours=ttl_h,
+        idle_minutes=idle_m,
+        optimizations=opt_tokens,
+        description=f"tuned {date}: ${winner.cost_per_million:.3f}/1M{p95} on {winner.gpu_desc}",
+    )
+    profiles.save(p)
+    console.print(
+        f"[green]✓[/] Saved profile [bold]{name}[/] — reproduce with "
+        f"[bold]aiod spin --profile {name}[/]."
+    )
+
+
+@app.command()
+def tune(
+    model: str = typer.Argument(None, help="HuggingFace link / org-name, or a profile name"),
+    provider: str = typer.Option(None, "--provider", help="Backend: vast | runpod"),
+    quant: list[str] = typer.Option(
+        None, "--quant", "-q", help="Quant to sweep (repeatable; >1 engages an opt-combo sweep)"
+    ),
+    context: int = typer.Option(None, "--context", help="Max model length to serve"),
+    opt: list[str] = typer.Option(
+        None, "--opt", help="Base/forced opt KEY or KEY=VAL, always applied (repeatable)"
+    ),
+    sweep_opt: list[str] = typer.Option(
+        None,
+        "--sweep-opt",
+        help="Opt AXIS to sweep: bare KEY = on/off, KEY=v1,v2 = value grid (repeatable)",
+    ),
+    concurrency: str = typer.Option(
+        "1,4,8,16", "--concurrency", "-c", help="Concurrency ladder (c=1 is a TTFT-floor reference)"
+    ),
+    ttft_p95: float = typer.Option(None, "--ttft-p95", help="Latency bar: max TTFT p95 (s)"),
+    ttft_p50: float = typer.Option(None, "--ttft-p50", help="Latency bar: max TTFT p50 (s)"),
+    min_decode: float = typer.Option(None, "--min-decode", help="Latency bar: min decode tok/s"),
+    max_cost: float = typer.Option(
+        None, "--max-cost", help="REQUIRED hard $ ceiling for the whole sweep (or --yes-i-know)"
+    ),
+    max_minutes: int = typer.Option(30, "--max-minutes", help="Wall-clock cap, minutes"),
+    max_price: float = typer.Option(None, "--max-price", help="Per-box $/hr cap"),
+    ttl: float = typer.Option(None, "--ttl", help="Auto-destroy reminder window, hours"),
+    idle: int = typer.Option(None, "--idle", help="Auto-shutdown after N idle minutes"),
+    n: int = typer.Option(8, "--n", help="Requests per benchmark point"),
+    max_tokens: int = typer.Option(256, "--max-tokens", help="Output tokens per request"),
+    prompt: str = typer.Option(None, "--prompt", help="Override the benchmark prompt"),
+    dry_run: bool = typer.Option(
+        False, "--dry-run", help="Estimate + plan only, rent nothing ($0)"
+    ),
+    yes: bool = typer.Option(False, "--yes", "-y", help="Skip the confirmation prompt"),
+    yes_i_know: bool = typer.Option(
+        False, "--yes-i-know", help="Run with NO --max-cost (uncapped — dangerous)"
+    ),
+    json_out: bool = typer.Option(False, "--json", help="Machine-readable output"),
+    save_profile: str = typer.Option(
+        None, "--save-profile", help="Save the measured winner as a profile NAME"
+    ),
+    force: bool = typer.Option(
+        False, "--force", help="With --save-profile, overwrite a built-in profile name"
+    ),
+):
+    """Sweep a box for the cheapest $/1M-token config meeting a latency bar.
+
+    Default: ONE box, ONE model load, concurrency ladder only (cheap). Pass
+    --sweep-opt (or more than one --quant) to engage an opt-combo relaunch sweep.
+    --max-cost is REQUIRED so the cost gate can never be silently absent.
+    """
+    if max_cost is None and not yes_i_know:
+        console.print(
+            "[red]--max-cost is required[/] (a hard $ ceiling for the whole sweep). "
+            "Pass e.g. [bold]--max-cost 0.50[/], or [bold]--yes-i-know[/] to run uncapped."
+        )
+        raise typer.Exit(1)
+
+    prof = profiles.get(model) if model else None
+    repo = prof.model if prof else model
+    if not repo:
+        console.print("[red]Provide a model or a profile name.[/] See [bold]aiod profile list[/].")
+        raise typer.Exit(1)
+
+    s = _settings_or_exit()
+    provider = (provider or (prof.provider if prof else "vast")).lower()
+    _require_provider_key(s, provider)
+
+    quants = list(quant) if quant else ([prof.quant] if prof and prof.quant else ["bf16"])
+    context = context if context is not None else (prof.context if prof else None)
+    ttl_h = (
+        ttl if ttl is not None
+        else (prof.ttl_hours if prof and prof.ttl_hours is not None else s.ttl_hours)
+    )
+    idle_m = idle if idle is not None else (prof.idle_minutes if prof else None)
+    max_p = (
+        max_price if max_price is not None
+        else (prof.max_price if prof and prof.max_price is not None else s.max_price)
+    )
+    base_tokens = _opt_tokens(opt, prof)
+    _validate_opts(base_tokens)
+    ladder = _parse_ladder(concurrency)
+    ladder_max = max(ladder)
+
+    if state.load() is not None:
+        console.print(
+            "[yellow]An instance is already tracked.[/] Run `aiod status` or `aiod teardown` first."
+        )
+        raise typer.Exit(1)
+
+    axes = tune_mod.parse_sweep_axes(sweep_opt)
+    mode_b = bool(axes) or len(quants) > 1
+    combos = tune_mod.build_combos(repo, base_tokens, axes, quants, max_conc=ladder_max)
+    if not combos:
+        console.print("[red]No valid configurations to sweep.[/]")
+        raise typer.Exit(1)
+
+    def _size(repo_arg, **kw):
+        return size_any(repo_arg, hf_token=s.hf_token, **kw)
+
+    projected: dict[str, float] = {}
+    try:
+        client_cm = providers.get_client(provider, s)
+    except providers.ProviderError as e:
+        console.print(f"[red]{e}[/]")
+        raise typer.Exit(1) from e
+
+    with console.status("Sizing & pricing combos (no rent)..."), client_cm as client:
+        def _price_plan(plan, disk, max_price=None):
+            return client.price_plan(plan, disk, max_price=max_price)
+
+        disk_by_quant: dict[str, float] = {}
+        for q in quants:
+            try:
+                szq = _size(repo, quants=[q], context_len=context, concurrency=ladder_max)
+                pq = szq.plan(q)
+                disk_by_quant[q] = recommend_disk_gb(pq.weights_gb) if pq else 50.0
+            except Exception:  # noqa: BLE001 - projection is best-effort
+                disk_by_quant[q] = 50.0
+        for combo in combos:
+            try:
+                dph = tune_mod.project_combo(
+                    combo,
+                    repo=repo,
+                    context=context,
+                    max_conc=ladder_max,
+                    size_any=_size,
+                    price_plan=_price_plan,
+                    pick_cheapest=_pick_cheapest,
+                    disk=disk_by_quant.get(combo.quant, 50.0),
+                    max_price=max_p,
+                )
+            except Exception:  # noqa: BLE001
+                dph = None
+            if dph is not None:
+                projected[combo.key] = dph
+
+    rentable = [c for c in combos if c.key in projected]
+    rentable.sort(key=lambda c: projected[c.key])
+    if not rentable:
+        console.print(
+            "[red]No combo has a GPU offer that fits within the price cap.[/] "
+            "tune optimizes vLLM (safetensors) models; raise --max-price or try another model."
+        )
+        raise typer.Exit(1)
+
+    contingency = 1.5 if mode_b else 1.0
+    load_guess = 6.0
+    est_cost, est_minutes = tune_mod.estimate(
+        rentable, projected,
+        load_minutes_guess=load_guess, per_point_minutes=1.0, n_points=len(ladder),
+        cold_pull_contingency=contingency,
+    )
+    dphs = [projected[c.key] for c in rentable]
+    mode_desc = "opt-combo sweep" if mode_b else "concurrency ladder only"
+    caps_line = (
+        f"Caps: max-cost ${max_cost:.2f} · max-minutes {max_minutes}"
+        if max_cost is not None
+        else "Caps: [red]UNCAPPED (--yes-i-know)[/] · max-minutes " + str(max_minutes)
+    )
+    console.print(
+        Panel(
+            f"[bold]{repo}[/]\n"
+            f"Combos: {len(rentable)} ({mode_desc})  ·  quants: {', '.join(quants)}\n"
+            f"Ladder: {ladder}  ·  bench n={n}, max_tokens={max_tokens}\n"
+            f"Projected $/hr: ${min(dphs):.2f}–${max(dphs):.2f} per box\n"
+            f"Estimate: [bold]~${est_cost:.2f}[/]  ·  ~{est_minutes:.0f} min  "
+            f"[dim](load time is the least predictable term)[/]\n"
+            f"{caps_line}",
+            title="Tune plan",
+            border_style="cyan",
+            expand=False,
+        )
+    )
+
+    if max_cost is not None and est_cost > max_cost:
+        console.print(
+            f"[red]Estimated ~${est_cost:.2f} exceeds --max-cost ${max_cost:.2f}.[/] "
+            f"Narrow the sweep (fewer combos / shorter ladder) or raise --max-cost."
+        )
+        raise typer.Exit(1)
+
+    if dry_run:
+        console.print("[dim]--dry-run: nothing rented.[/]")
+        raise typer.Exit(0)
+
+    if not yes and not typer.confirm(
+        f"Rent and sweep {len(rentable)} config(s) (est ~${est_cost:.2f})?"
+    ):
+        raise typer.Exit(0)
+
+    def _progress(phase: str, msg: str = "") -> None:
+        console.print(f"[dim]{phase}: {msg}[/]")
+
+    def _launch(combo):
+        return engine.launch(
+            s, model=repo, quant=combo.quant, provider=provider, max_price=max_p,
+            ttl_hours=ttl_h, idle_minutes=idle_m, context=context, concurrency=ladder_max,
+            optimizations=combo.tokens, startup_grace=540, on_event=_progress,
+        )
+
+    def _bench(inst, c):
+        from .bench import DEFAULT_PROMPT, run_benchmark
+
+        return run_benchmark(
+            inst.base_url, inst.repo_id, api_key=inst.api_key, n=n, concurrency=c,
+            max_tokens=max_tokens, prompt=prompt or DEFAULT_PROMPT, price_per_hr=inst.price_per_hr,
+        )
+
+    def _destroy(inst):
+        engine.destroy(s, inst)
+
+    guard = tune_mod.CostGuard(max_cost=max_cost, max_minutes=float(max_minutes))
+    deps = tune_mod.SweepDeps(
+        launch=_launch, bench=_bench, destroy=_destroy,
+        state_load=state.load, state_clear=state.clear, on_event=_progress,
+    )
+    plan = tune_mod.SweepPlan(
+        combos=rentable, ladder=ladder, guard=guard, projected_dph=projected,
+        ttft_p95=ttft_p95, ttft_p50=ttft_p50, min_decode=min_decode, load_minutes_guess=load_guess,
+    )
+
+    import signal
+
+    prev_term = signal.getsignal(signal.SIGTERM)
+
+    def _on_term(_signum, _frame):
+        raise KeyboardInterrupt
+
+    result = None
+    try:
+        try:
+            signal.signal(signal.SIGTERM, _on_term)
+        except (ValueError, OSError):
+            pass
+        result = tune_mod.run_sweep(deps, plan)
+    except KeyboardInterrupt:
+        console.print("[yellow]Interrupted — tearing down.[/]")
+    finally:
+        try:
+            signal.signal(signal.SIGTERM, prev_term)
+        except (ValueError, OSError):
+            pass
+        _emergency_teardown(s)
+
+    rows = result.rows if result else []
+    has_bar = any(x is not None for x in (ttft_p95, ttft_p50, min_decode))
+    valid, passing = tune_mod.rank(
+        rows, ttft_p95=ttft_p95, ttft_p50=ttft_p50, min_decode=min_decode
+    )
+    rec = tune_mod.recommend(valid, passing, has_bar=has_bar)
+
+    # Modeled rows for rentable combos we never measured (display only, ~marked).
+    measured_keys = {(r.quant, tuple(r.opt_keys), r.concurrency) for r in rows if r.ok > 0}
+    baseline_thrpt = max((r.throughput_tok_s for r in valid if r.throughput_tok_s), default=None)
+    projected_rows = []
+    for combo in rentable:
+        if any(r[0] == combo.quant and r[1] == tuple(combo.opt_keys) for r in measured_keys):
+            continue
+        pr = tune_mod.projected_row(
+            combo, dph=projected.get(combo.key), baseline_throughput=baseline_thrpt,
+            gpu_desc="", concurrency=ladder_max,
+        )
+        if pr is not None:
+            projected_rows.append(pr)
+
+    if json_out:
+        import dataclasses
+        import json as _json
+
+        payload = {
+            "rows": [dataclasses.asdict(r) for r in valid + projected_rows],
+            "recommendation": dataclasses.asdict(rec.row) if rec.row else None,
+            "reason": rec.reason,
+            "fallback": rec.fallback,
+            "stop_reason": result.stop_reason if result else None,
+            "interrupted": result.interrupted if result else False,
+        }
+        console.print_json(_json.dumps(payload))
+    else:
+        if result and result.stop_reason in ("max-cost", "max-minutes"):
+            console.print(
+                f"[yellow]Stopped early: hit --{result.stop_reason}.[/] Showing partial results."
+            )
+        if not valid:
+            console.print("[red]No measured rows.[/] Try raising --max-minutes or --max-cost.")
+        else:
+            _render_leaderboard(valid, projected_rows, rec, has_bar=has_bar)
+            if rec.row is not None:
+                w = rec.row
+                opts_str = " ".join(w.opt_tokens)
+                opt_flag = f" --opt {' --opt '.join(w.opt_tokens)}" if w.opt_tokens else ""
+                console.print(
+                    Panel(
+                        f"{rec.reason}\n"
+                        f"[bold]{w.quant}[/] @ c={w.concurrency} on {w.gpu_desc}  ·  "
+                        f"[bold]${w.cost_per_million:.3f}/1M[/]  ·  "
+                        f"p95={_fmt(w.ttft_p95, 's')}  ·  opts: {opts_str or '(none)'}\n"
+                        f"[dim]Reproduce:[/] aiod spin {repo} --quant {w.quant} -c {w.concurrency}{opt_flag}",
+                        title="★ Recommendation" + ("  (fallback)" if rec.fallback else ""),
+                        border_style="green" if not rec.fallback else "yellow",
+                        expand=False,
+                    )
+                )
+
+    if save_profile:
+        if rec.row is None or (has_bar and rec.fallback):
+            console.print(
+                "[yellow]Not saving a profile:[/] no measured config met the latency bar. "
+                "Relax the bar or raise --n."
+            )
+        else:
+            _save_tuned_profile(
+                save_profile, repo=repo, provider=provider, winner=rec.row,
+                context=context, ttl_h=ttl_h, idle_m=idle_m, force=force,
+            )
 
 
 @app.command()

--- a/aiod/engine.py
+++ b/aiod/engine.py
@@ -30,6 +30,7 @@ def launch(
     tool_parser: str | None = None,  # None -> resolve from model_configs
     extra_args: list[str] | None = None,
     optimizations: list[str] | None = None,  # opt selection tokens (KEY or KEY=VAL)
+    startup_grace: float | None = None,  # None -> today's exact 1200s boot loop
     on_event=None,
 ) -> state.Instance | None:
     """Size → find cheapest fit → rent → wait for boot + model load. Saves state
@@ -111,12 +112,32 @@ def launch(
 
             ep = None
             start = time.time()
+            seen_running = False
             while time.time() - start < 1200:  # slow nodes pull the image slowly
                 vi = client.get_instance(instance_id)
                 ep = client.endpoint_of(vi, CONTAINER_PORT)
-                emit("booting", f"{client.status_of(vi)} ({int(time.time() - start)}s)")
+                st = client.status_of(vi)
+                if "running" in st.lower():
+                    seen_running = True
+                emit("booting", f"{st} ({int(time.time() - start)}s)")
                 if ep:
                     break
+                # Early-abort a bad node (stuck pulling the image) instead of
+                # billing the full 1200s — mirrors cli._wait_for_endpoint. Only
+                # active when a caller passes startup_grace (tune passes 540);
+                # default None preserves today's exact boot loop byte-for-byte.
+                if (
+                    startup_grace is not None
+                    and not seen_running
+                    and (time.time() - start) > startup_grace
+                ):
+                    emit(
+                        "error",
+                        "host never started container (slow/bad node) — aborting early",
+                    )
+                    inst.status = "error"
+                    state.save(inst)
+                    return inst
                 time.sleep(10)
             if not ep:
                 emit("error", "port never mapped (machine may lack free direct ports)")

--- a/aiod/tune.py
+++ b/aiod/tune.py
@@ -1,0 +1,637 @@
+"""Pure core for `aiod tune` — the cost-per-million-token optimizer.
+
+This module is deliberately side-effect-free and dependency-light: every
+money/IO operation (renting a box, benchmarking it, sizing/pricing) is *injected*
+as a callable, so the whole "money path" is unit-testable without Typer, the
+network, or a real provider.
+
+Responsibilities (all pure unless a dep is called):
+
+  * :class:`TuneRow` / :class:`Combo` / :class:`Recommendation` — value types.
+  * :func:`build_combos` — enumerate the (quant x opt-axis) sweep, routing every
+    candidate through :func:`optimizations.resolve` (the SOLE validator) and
+    de-duplicating. Always includes the no-opt control.
+  * :func:`project_combo` — size + price a combo to a projected $/hr (or None to
+    skip it) without renting anything.
+  * :func:`rank` / :func:`recommend` — order rows by measured $/1M and pick the
+    cheapest *measured* row meeting the latency bar. Projected rows are NEVER
+    recommended.
+  * :class:`CostGuard` — hard $/minute caps enforced at every boundary.
+  * :func:`estimate` — up-front $ / wall-clock estimate from projected $/hr.
+  * :func:`run_sweep` — the lifecycle orchestration (launch -> ladder -> teardown)
+    with launch/bench/destroy/state INJECTED, so teardown invariants are testable
+    with everything mocked.
+"""
+
+from __future__ import annotations
+
+import itertools
+import time
+from collections.abc import Callable
+from dataclasses import dataclass, field
+from typing import Any
+
+from . import optimizations
+
+# --------------------------------------------------------------------------- #
+# Value types
+# --------------------------------------------------------------------------- #
+
+
+@dataclass
+class TuneRow:
+    """One leaderboard row — a measured (combo, concurrency) point, or a modeled
+    (``projected=True``) row. Projected rows are display/ordering only and are
+    never eligible to be the recommendation."""
+
+    opt_keys: list[str]
+    opt_values: dict[str, str]
+    opt_tokens: list[str]
+    quant: str
+    gpu_desc: str
+    price_per_hr: float | None
+    concurrency: int
+    cost_per_million: float | None
+    throughput_tok_s: float | None
+    ttft_p50: float | None
+    ttft_p95: float | None
+    avg_decode_tok_s: float | None
+    ok: int
+    n: int
+    projected: bool = False
+    error: str | None = None
+
+
+@dataclass
+class Combo:
+    """One launch configuration in the sweep (opts are frozen at engine.launch,
+    so a combo == one model load). ``key`` is a stable de-dupe id."""
+
+    quant: str
+    tokens: list[str]
+    opt_keys: list[str]
+    opt_values: dict[str, str]
+    key: str
+
+
+@dataclass
+class Recommendation:
+    row: TuneRow | None
+    reason: str
+    fallback: bool
+
+
+# --------------------------------------------------------------------------- #
+# Combo enumeration
+# --------------------------------------------------------------------------- #
+
+
+def parse_sweep_axes(specs: list[str] | None) -> list[list[str | None]]:
+    """Parse ``--sweep-opt`` specs into opt axes.
+
+    A bare ``KEY`` becomes an on/off toggle axis ``[None, "KEY"]``; a
+    ``KEY=v1,v2`` grid becomes a value axis ``["KEY=v1", "KEY=v2"]``.
+    """
+    axes: list[list[str | None]] = []
+    for spec in specs or []:
+        if spec is None:
+            continue
+        if "=" in spec:
+            key, grid = spec.split("=", 1)
+            key = key.strip()
+            vals = [v.strip() for v in grid.split(",") if v.strip()]
+            axes.append([f"{key}={v}" for v in vals])
+        else:
+            key = spec.strip()
+            if not key:
+                continue
+            axes.append([None, key])
+    return axes
+
+
+def _combo_key(quant: str, keys: list[str], values: dict[str, str]) -> str:
+    """Stable de-dupe id: quant + the resolved key SET + the value map of the
+    value-bearing keys (so distinct max-num-seqs grids don't collapse)."""
+    kf = ",".join(sorted(keys))
+    vf = ",".join(f"{k}={values[k]}" for k in sorted(values) if k in keys)
+    return f"{quant}|{kf}|{vf}"
+
+
+def build_combos(
+    repo: str,
+    base_tokens: list[str] | None,
+    sweep_axes: list[list[str | None]] | None,
+    quants: list[str] | None,
+    *,
+    engine: str = "vllm",
+    draft_model: str | None = None,
+    max_conc: int = 16,
+) -> list[Combo]:
+    """Cartesian product of ``quants`` x opt axes -> de-duplicated combos.
+
+    Every candidate is routed through :func:`optimizations.resolve` (the sole
+    validator): a ``conflicts_with`` pair, a duplicate ``provides``, or a value on
+    a toggle raises ``ValueError`` and the candidate is dropped. ``resolve`` also
+    gates out non-applicable opts (e.g. speculative-decoding with no draft model),
+    so those candidates collapse onto the control via de-dup. The no-opt control
+    (``opt_keys=[]``) is always present.
+    """
+    base = list(base_tokens or [])
+    axes = sweep_axes or []
+    quants = quants or ["bf16"]
+
+    if axes:
+        axis_choices: list[tuple] = list(itertools.product(*axes))
+    else:
+        axis_choices = [()]
+
+    combos: list[Combo] = []
+    seen: set[str] = set()
+    for quant in quants:
+        # Control (base opts only) first, then every axis combination.
+        candidates: list[list[str]] = [list(base)]
+        for choice in axis_choices:
+            candidates.append(base + [t for t in choice if t is not None])
+
+        for tokens in candidates:
+            keys, values = optimizations.parse_selection(tokens)
+            ctx = optimizations.OptContext(
+                engine=engine,
+                quant=quant,
+                repo_id=repo,
+                concurrency=max_conc,
+                draft_model=draft_model,
+            )
+            try:
+                resolved = optimizations.resolve(keys, values, ctx)
+            except ValueError:
+                # conflict / dup-provides / value-on-toggle — resolve is the SOLE
+                # validator; drop the candidate (never re-walk conflicts here).
+                continue
+            rkeys = list(resolved.keys)
+            if resolved.requirements.needs_draft_model and not draft_model:
+                continue
+            rel_values = {k: values[k] for k in rkeys if k in values}
+            key = _combo_key(quant, rkeys, rel_values)
+            if key in seen:
+                continue
+            seen.add(key)
+            tokens_out = [f"{k}={rel_values[k]}" if k in rel_values else k for k in rkeys]
+            combos.append(
+                Combo(
+                    quant=quant,
+                    tokens=tokens_out,
+                    opt_keys=rkeys,
+                    opt_values=dict(rel_values),
+                    key=key,
+                )
+            )
+    return combos
+
+
+# --------------------------------------------------------------------------- #
+# Sizing projection (no rent)
+# --------------------------------------------------------------------------- #
+
+
+def project_combo(
+    combo: Combo,
+    *,
+    repo: str,
+    context: int | None,
+    max_conc: int,
+    size_any: Callable[..., Any],
+    price_plan: Callable[..., Any],
+    pick_cheapest: Callable[[Any], Any],
+    disk: float,
+    max_price: float | None,
+) -> float | None:
+    """Project a combo's $/hr without renting: ``size_any`` -> cheapest GPU fit ->
+    ``price_plan`` -> ``pick_cheapest`` -> dph. Returns None (combo skipped) when
+    the engine isn't vLLM (opts don't apply to GGUF) or nothing fits/prices.
+    """
+    sizing = size_any(
+        repo,
+        quants=[combo.quant],
+        context_len=context,
+        concurrency=max_conc,
+        opts=combo.opt_keys,
+        opt_values=combo.opt_values,
+    )
+    if getattr(sizing, "engine", "vllm") != "vllm":
+        return None
+    plan = sizing.plan(combo.quant)
+    if plan is None or plan.cheapest_fit is None:
+        return None
+    priced = price_plan(plan, disk, max_price=max_price)
+    best = pick_cheapest(priced)
+    if best is None or getattr(best, "offer", None) is None:
+        return None
+    return best.offer.dph_total
+
+
+# --------------------------------------------------------------------------- #
+# Ranking + recommendation
+# --------------------------------------------------------------------------- #
+
+_INF = float("inf")
+
+
+def _p95_key(r: TuneRow) -> float:
+    return r.ttft_p95 if r.ttft_p95 is not None else _INF
+
+
+def rank(
+    rows: list[TuneRow],
+    *,
+    ttft_p95: float | None = None,
+    ttft_p50: float | None = None,
+    min_decode: float | None = None,
+) -> tuple[list[TuneRow], list[TuneRow]]:
+    """Return ``(valid_sorted, passing)``.
+
+    ``valid`` = rows with ``ok>0`` and a real ``cost_per_million``, sorted
+    ascending by $/1M (tie-break: lower ttft_p95). ``passing`` = ``valid``
+    filtered by the (None-guarded) latency bars.
+    """
+    valid = [r for r in rows if r.ok > 0 and r.cost_per_million is not None]
+    valid_sorted = sorted(valid, key=lambda r: (r.cost_per_million, _p95_key(r)))
+
+    def passes(r: TuneRow) -> bool:
+        if ttft_p95 is not None and (r.ttft_p95 is None or r.ttft_p95 > ttft_p95):
+            return False
+        if ttft_p50 is not None and (r.ttft_p50 is None or r.ttft_p50 > ttft_p50):
+            return False
+        if min_decode is not None and (
+            r.avg_decode_tok_s is None or r.avg_decode_tok_s < min_decode
+        ):
+            return False
+        return True
+
+    passing = [r for r in valid_sorted if passes(r)]
+    return valid_sorted, passing
+
+
+def recommend(
+    valid: list[TuneRow],
+    passing: list[TuneRow],
+    *,
+    has_bar: bool,
+) -> Recommendation:
+    """Pick the winner. The winner is ALWAYS a measured row (``projected=False``);
+    projected rows are excluded even when cheapest (Judge-3 fix).
+
+    Fallbacks: no bar -> cheapest measured valid row; bar set but nothing passing
+    -> the lowest-ttft_p95 measured row (flagged ``fallback=True`` with a reason).
+    """
+    measured_passing = [r for r in passing if not r.projected]
+    if measured_passing:
+        reason = (
+            "cheapest measured config meeting the latency bar"
+            if has_bar
+            else "cheapest measured config (no latency bar set)"
+        )
+        return Recommendation(row=measured_passing[0], reason=reason, fallback=False)
+
+    measured_valid = [r for r in valid if not r.projected]
+    if not measured_valid:
+        return Recommendation(
+            row=None,
+            reason="no measured rows to recommend",
+            fallback=True,
+        )
+    if not has_bar:
+        return Recommendation(
+            row=measured_valid[0],
+            reason="cheapest measured config (no latency bar set)",
+            fallback=False,
+        )
+    best = min(measured_valid, key=_p95_key)
+    return Recommendation(
+        row=best,
+        reason="no config met the latency bar; showing the lowest-TTFT measured config "
+        "(relax the bar or raise --n)",
+        fallback=True,
+    )
+
+
+def projected_row(
+    combo: Combo,
+    *,
+    dph: float | None,
+    baseline_throughput: float | None,
+    gpu_desc: str,
+    concurrency: int,
+) -> TuneRow | None:
+    """Build a modeled (``projected=True``) leaderboard row for a combo that was
+    not measured: assumes tok/s unchanged from the baseline (false for kv-fp8's
+    throughput effect — hence ``~`` in the UI and never recommended)."""
+    if dph is None or not baseline_throughput:
+        return None
+    cpm = (dph / 3600.0) / baseline_throughput * 1_000_000
+    return TuneRow(
+        opt_keys=list(combo.opt_keys),
+        opt_values=dict(combo.opt_values),
+        opt_tokens=list(combo.tokens),
+        quant=combo.quant,
+        gpu_desc=gpu_desc,
+        price_per_hr=dph,
+        concurrency=concurrency,
+        cost_per_million=cpm,
+        throughput_tok_s=baseline_throughput,
+        ttft_p50=None,
+        ttft_p95=None,
+        avg_decode_tok_s=None,
+        ok=0,
+        n=0,
+        projected=True,
+    )
+
+
+# --------------------------------------------------------------------------- #
+# Cost guard
+# --------------------------------------------------------------------------- #
+
+
+class CostGuard:
+    """Hard $ / wall-clock caps, enforced at every boundary.
+
+    ``spent`` = finished (torn-down) box cost + the live box's
+    ``est_cost_so_far``. ``check`` returns a stop-reason string or None.
+    """
+
+    def __init__(
+        self,
+        max_cost: float | None = None,
+        max_minutes: float | None = None,
+        *,
+        clock: Callable[[], float] = time.monotonic,
+    ) -> None:
+        self.max_cost = max_cost
+        self.max_minutes = max_minutes
+        self._clock = clock
+        self._start = clock()
+        self.finished_total = 0.0
+
+    def add_finished(self, cost: float) -> None:
+        self.finished_total += max(0.0, cost or 0.0)
+
+    def spent(self, live_inst: Any | None = None, finished_total: float | None = None) -> float:
+        ft = self.finished_total if finished_total is None else finished_total
+        live = getattr(live_inst, "est_cost_so_far", 0.0) if live_inst is not None else 0.0
+        return ft + (live or 0.0)
+
+    def would_exceed(self, next_box_est: float, live_inst: Any | None = None) -> bool:
+        if self.max_cost is None:
+            return False
+        return self.spent(live_inst) + max(0.0, next_box_est or 0.0) > self.max_cost
+
+    def elapsed_minutes(self) -> float:
+        return (self._clock() - self._start) / 60.0
+
+    def time_exceeded(self) -> bool:
+        if self.max_minutes is None:
+            return False
+        return self.elapsed_minutes() >= self.max_minutes
+
+    def check(self, live_inst: Any | None = None) -> str | None:
+        if self.max_cost is not None and self.spent(live_inst) >= self.max_cost:
+            return "max-cost"
+        if self.time_exceeded():
+            return "max-minutes"
+        return None
+
+
+# --------------------------------------------------------------------------- #
+# Up-front estimate
+# --------------------------------------------------------------------------- #
+
+
+def estimate(
+    combos: list[Combo],
+    projected_dph_by_key: dict[str, float],
+    *,
+    load_minutes_guess: float,
+    per_point_minutes: float,
+    n_points: int,
+    cold_pull_contingency: float = 1.0,
+) -> tuple[float, float]:
+    """Up-front (est_cost, est_minutes) from injected projected $/hr.
+
+    Each box costs ``dph/60 * box_minutes`` where ``box_minutes`` = the
+    (contingency-widened) load guess + a bench point per ladder rung. Mode-B
+    multi-combo sweeps pass ``cold_pull_contingency>1`` to widen the least
+    predictable term (cold HF pulls on vast).
+    """
+    load = max(0.0, load_minutes_guess) * max(1.0, cold_pull_contingency)
+    est_cost = 0.0
+    est_minutes = 0.0
+    for combo in combos:
+        dph = projected_dph_by_key.get(combo.key)
+        if dph is None:
+            continue
+        box_minutes = load + per_point_minutes * max(0, n_points)
+        est_minutes += box_minutes
+        est_cost += dph / 60.0 * box_minutes
+    return est_cost, est_minutes
+
+
+# --------------------------------------------------------------------------- #
+# Orchestration (deps injected -> fully mockable)
+# --------------------------------------------------------------------------- #
+
+
+@dataclass
+class SweepDeps:
+    """Injected money/IO operations. ``destroy`` should be idempotent against a
+    box that is already gone (provider 404 == success)."""
+
+    launch: Callable[[Combo], Any]  # (combo) -> Instance | None
+    bench: Callable[[Any, int], Any]  # (inst, concurrency) -> BenchResult
+    destroy: Callable[[Any], Any]  # (inst) -> None
+    state_load: Callable[[], Any]  # () -> Instance | None
+    state_clear: Callable[[], None]  # () -> None
+    on_event: Callable[[str, str], None] = lambda *_a: None
+
+
+@dataclass
+class SweepPlan:
+    combos: list[Combo]
+    ladder: list[int]
+    guard: CostGuard
+    projected_dph: dict[str, float] = field(default_factory=dict)
+    ttft_p95: float | None = None
+    ttft_p50: float | None = None
+    min_decode: float | None = None
+    early_stop: bool = True
+    load_minutes_guess: float = 6.0
+
+
+@dataclass
+class SweepResult:
+    rows: list[TuneRow]
+    stop_reason: str | None = None
+    interrupted: bool = False
+
+
+def _failure_row(combo: Combo, inst: Any | None, error: str | None) -> TuneRow:
+    return TuneRow(
+        opt_keys=list(combo.opt_keys),
+        opt_values=dict(combo.opt_values),
+        opt_tokens=list(combo.tokens),
+        quant=combo.quant,
+        gpu_desc=getattr(inst, "gpu_desc", "") if inst is not None else "",
+        price_per_hr=getattr(inst, "price_per_hr", None) if inst is not None else None,
+        concurrency=0,
+        cost_per_million=None,
+        throughput_tok_s=None,
+        ttft_p50=None,
+        ttft_p95=None,
+        avg_decode_tok_s=None,
+        ok=0,
+        n=0,
+        error=error or "launch failed",
+    )
+
+
+def _row_from_bench(combo: Combo, inst: Any, concurrency: int, res: Any) -> TuneRow:
+    okn = len(res.ok)
+    return TuneRow(
+        opt_keys=list(combo.opt_keys),
+        opt_values=dict(combo.opt_values),
+        opt_tokens=list(combo.tokens),
+        quant=combo.quant,
+        gpu_desc=getattr(inst, "gpu_desc", ""),
+        price_per_hr=getattr(inst, "price_per_hr", None),
+        concurrency=concurrency,
+        cost_per_million=res.cost_per_million,
+        throughput_tok_s=res.throughput_tok_s,
+        ttft_p50=res.ttft_p50,
+        ttft_p95=res.ttft_p95,
+        avg_decode_tok_s=res.avg_decode_tok_s,
+        ok=okn,
+        n=res.n,
+        error=None if okn else "all requests failed",
+    )
+
+
+def _box_est(dph: float | None, plan: SweepPlan) -> float:
+    """Rough cost of one box for the whole ladder (used at the launch boundary)."""
+    if dph is None:
+        return 0.0
+    minutes = plan.load_minutes_guess + 1.0 * max(1, len(plan.ladder))
+    return dph / 60.0 * minutes
+
+
+def run_sweep(deps: SweepDeps, plan: SweepPlan) -> SweepResult:
+    """Sequential lifecycle: for each combo, launch one box, run the concurrency
+    ladder, then GUARANTEE teardown — on success, error, or KeyboardInterrupt —
+    destroying ``inst`` if bound else ``state_load()`` (covers the boot window
+    before ``inst`` is bound). Hard caps are checked at every boundary.
+    """
+    rows: list[TuneRow] = []
+    guard = plan.guard
+    stop_reason: str | None = None
+    interrupted = False
+    incumbent: float | None = None  # best measured $/1M so far
+    best_throughput: float | None = None
+
+    def teardown(inst: Any | None) -> None:
+        target = inst if inst is not None else deps.state_load()
+        if target is not None:
+            try:
+                deps.destroy(target)
+            except Exception:  # noqa: BLE001 - destroy on a gone box is harmless
+                pass
+        # belt-and-suspenders: the single state slot must be empty afterward.
+        try:
+            if deps.state_load() is not None:
+                deps.state_clear()
+        except Exception:  # noqa: BLE001
+            pass
+
+    try:
+        for combo in plan.combos:
+            r = guard.check()
+            if r is not None:
+                stop_reason = r
+                break
+            dph = plan.projected_dph.get(combo.key)
+            if dph is not None and guard.would_exceed(_box_est(dph, plan)):
+                stop_reason = "max-cost"
+                break
+            # Early-stop: a combo whose projected $/1M floor can't beat the
+            # incumbent is never rented.
+            if (
+                plan.early_stop
+                and incumbent is not None
+                and dph is not None
+                and best_throughput
+            ):
+                floor = (dph / 3600.0) / best_throughput * 1_000_000
+                if floor >= incumbent:
+                    deps.on_event(
+                        "skip",
+                        f"{combo.key}: projected floor ~${floor:.3f}/1M can't beat "
+                        f"${incumbent:.3f}/1M",
+                    )
+                    continue
+
+            inst: Any | None = None
+            try:
+                try:
+                    inst = deps.launch(combo)
+                except KeyboardInterrupt:
+                    raise
+                except Exception as e:  # noqa: BLE001 - record + continue the sweep
+                    rows.append(_failure_row(combo, None, str(e)))
+                    continue
+                if inst is None or getattr(inst, "status", None) != "running":
+                    rows.append(_failure_row(combo, inst, getattr(inst, "status", None)))
+                    continue
+
+                for c in plan.ladder:
+                    r = guard.check(live_inst=inst)
+                    if r is not None:
+                        stop_reason = r
+                        break
+                    try:
+                        res = deps.bench(inst, c)
+                    except KeyboardInterrupt:
+                        raise
+                    except Exception as e:  # noqa: BLE001
+                        rows.append(_failure_row(combo, inst, str(e)))
+                        break
+                    row = _row_from_bench(combo, inst, c, res)
+                    rows.append(row)
+                    if row.cost_per_million is not None and row.ok > 0:
+                        if incumbent is None or row.cost_per_million < incumbent:
+                            incumbent = row.cost_per_million
+                    if row.throughput_tok_s and (
+                        best_throughput is None or row.throughput_tok_s > best_throughput
+                    ):
+                        best_throughput = row.throughput_tok_s
+                    r = guard.check(live_inst=inst)
+                    if r is not None:
+                        stop_reason = r
+                        break
+            finally:
+                if inst is not None:
+                    guard.add_finished(getattr(inst, "est_cost_so_far", 0.0) or 0.0)
+                teardown(inst)
+
+            if stop_reason is not None:
+                break
+    except KeyboardInterrupt:
+        interrupted = True
+        teardown(deps.state_load())
+        stop_reason = stop_reason or "interrupted"
+
+    # Final safety net: the single state slot MUST be empty when we return.
+    try:
+        if deps.state_load() is not None:
+            teardown(deps.state_load())
+    except Exception:  # noqa: BLE001
+        pass
+
+    return SweepResult(rows=rows, stop_reason=stop_reason, interrupted=interrupted)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "aiondemandcluster"
-version = "0.4.0"
+version = "0.5.0"
 description = "AI on Demand — spin up a HuggingFace model on vast.ai GPUs and drive it from Claude Code via Claude Code Router."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/tests/test_cli_up.py
+++ b/tests/test_cli_up.py
@@ -65,7 +65,12 @@ def test_up_spin_kwargs_match_engine_launch_signature(wired):
     result = runner.invoke(app, ["up", "org/repo"])
     assert result.exit_code == 0, result.output
     spin_kwargs = wired["run_gateway"]["spin_kwargs"]
-    launch_params = set(inspect.signature(engine.launch).parameters) - {"s", "on_event"}
+    # `startup_grace` is an additive launch-tuning kwarg (used by `aiod tune` for
+    # early bad-node abort); like `on_event` it's not part of the spin config the
+    # gateway threads through, so it's excluded from this in-sync check.
+    launch_params = set(inspect.signature(engine.launch).parameters) - {
+        "s", "on_event", "startup_grace"
+    }
     assert set(spin_kwargs) == launch_params
 
 

--- a/tests/test_tune.py
+++ b/tests/test_tune.py
@@ -1,0 +1,884 @@
+"""Unit + orchestration tests for `aiod tune`.
+
+Everything on the money path is injected/mocked: build_combos routes through the
+real optimization registry (pure), while run_sweep is driven with fake
+launch/bench/destroy/state deps so we can assert the teardown invariants
+(success / exception / KeyboardInterrupt / boot-window-before-inst) without ever
+touching a provider. A single @pytest.mark.live smoke covers the real path.
+"""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+
+import pytest
+
+from aiod.tune import (
+    Combo,
+    CostGuard,
+    SweepDeps,
+    SweepPlan,
+    TuneRow,
+    build_combos,
+    estimate,
+    parse_sweep_axes,
+    project_combo,
+    rank,
+    recommend,
+    run_sweep,
+)
+
+# --------------------------------------------------------------------------- #
+# Helpers / fakes
+# --------------------------------------------------------------------------- #
+
+
+def _row(cpm=None, p95=None, p50=None, decode=None, thr=None, ok=1, n=8,
+         quant="bf16", keys=None, conc=4, projected=False):
+    return TuneRow(
+        opt_keys=keys or [],
+        opt_values={},
+        opt_tokens=keys or [],
+        quant=quant,
+        gpu_desc="1x RTX 4090 (24GB)",
+        price_per_hr=0.3,
+        concurrency=conc,
+        cost_per_million=cpm,
+        throughput_tok_s=thr,
+        ttft_p50=p50,
+        ttft_p95=p95,
+        avg_decode_tok_s=decode,
+        ok=ok,
+        n=n,
+        projected=projected,
+    )
+
+
+@dataclass
+class FakeInst:
+    """Stand-in for state.Instance with the bits run_sweep/CostGuard read."""
+
+    status: str = "running"
+    gpu_desc: str = "1x RTX 4090 (24GB)"
+    price_per_hr: float = 0.3
+    instance_id: int = 1
+    est_cost_so_far: float = 0.0
+
+
+@dataclass
+class FakeBench:
+    """Stand-in for bench.BenchResult."""
+
+    n: int = 8
+    cost_per_million: float | None = 1.0
+    throughput_tok_s: float | None = 500.0
+    ttft_p50: float | None = 0.2
+    ttft_p95: float | None = 0.4
+    avg_decode_tok_s: float | None = 60.0
+    _ok: int = 8
+
+    @property
+    def ok(self):
+        return [object()] * self._ok
+
+
+class FakeState:
+    """A one-slot state spine mirroring aiod.state (load/save/clear)."""
+
+    def __init__(self):
+        self.slot = None
+
+    def load(self):
+        return self.slot
+
+    def save(self, inst):
+        self.slot = inst
+
+    def clear(self):
+        self.slot = None
+
+
+def _deps(launch, bench, state, *, destroy=None, on_event=lambda *a: None):
+    calls = {"destroy": []}
+
+    def _destroy(inst):
+        calls["destroy"].append(inst)
+        if destroy:
+            destroy(inst)
+        # mirror engine.destroy: provider kill + state.clear()
+        state.clear()
+
+    d = SweepDeps(
+        launch=launch, bench=bench, destroy=_destroy,
+        state_load=state.load, state_clear=state.clear, on_event=on_event,
+    )
+    return d, calls
+
+
+# --------------------------------------------------------------------------- #
+# build_combos
+# --------------------------------------------------------------------------- #
+
+
+def test_build_combos_control_always_present():
+    combos = build_combos("org/m", [], [], ["bf16"])
+    assert len(combos) == 1
+    assert combos[0].opt_keys == []
+    assert combos[0].quant == "bf16"
+
+
+def test_build_combos_cartesian_quants_x_axes():
+    axes = parse_sweep_axes(["prefix-caching"])  # toggle: off/on
+    combos = build_combos("org/m", [], axes, ["bf16", "fp8"])
+    # 2 quants x {off(control), on} = 4 distinct combos
+    keys = {(c.quant, tuple(c.opt_keys)) for c in combos}
+    assert ("bf16", ()) in keys
+    assert ("bf16", ("prefix-caching",)) in keys
+    assert ("fp8", ()) in keys
+    assert ("fp8", ("prefix-caching",)) in keys
+    assert len(combos) == 4
+
+
+def test_build_combos_value_grid_distinct_combos():
+    axes = parse_sweep_axes(["max-num-seqs=128,256"])
+    combos = build_combos("org/m", [], axes, ["bf16"])
+    # control + two value points = 3 (the value map must keep 128 and 256 apart)
+    vals = sorted(c.opt_values.get("max-num-seqs") for c in combos if c.opt_keys)
+    assert vals == ["128", "256"]
+    assert len([c for c in combos if not c.opt_keys]) == 1  # control present
+
+
+def test_build_combos_value_on_toggle_dropped():
+    # prefix-caching takes no value -> resolve() raises -> candidate dropped.
+    axes = parse_sweep_axes(["prefix-caching=999"])
+    combos = build_combos("org/m", [], axes, ["bf16"])
+    # Only the control survives (the value-on-toggle candidate is dropped).
+    assert all(c.opt_keys == [] for c in combos)
+    assert len(combos) == 1
+
+
+def test_build_combos_dedupes_base_plus_axis_same_key():
+    # base forces max-num-seqs=256; the axis re-adds the same key -> dedup collapses
+    # the duplicate so we don't sweep an identical config twice.
+    axes = parse_sweep_axes(["max-num-seqs=256"])
+    combos = build_combos("org/m", ["max-num-seqs=256"], axes, ["bf16"])
+    seqs = [c for c in combos if "max-num-seqs" in c.opt_keys]
+    assert len(seqs) == 1
+    assert seqs[0].opt_values["max-num-seqs"] == "256"
+
+
+def test_build_combos_speculative_without_draft_collapses_to_control():
+    # speculative-decoding is inert (applies()==False) without a draft model, so
+    # it resolves to keys=[] and dedups onto the control.
+    axes = parse_sweep_axes(["speculative-decoding"])
+    combos = build_combos("org/m", [], axes, ["bf16"], draft_model=None)
+    assert all(c.opt_keys == [] for c in combos)
+    assert len(combos) == 1
+
+
+def test_build_combos_gguf_engine_yields_no_opt_sweep():
+    axes = parse_sweep_axes(["prefix-caching"])  # vllm-only opt
+    combos = build_combos("org/m", [], axes, ["Q4_K_M"], engine="llamacpp")
+    # prefix-caching doesn't apply to llamacpp -> every candidate collapses to control.
+    assert all(c.opt_keys == [] for c in combos)
+    assert len(combos) == 1
+
+
+# --------------------------------------------------------------------------- #
+# rank
+# --------------------------------------------------------------------------- #
+
+
+def test_rank_orders_by_cost_then_p95():
+    rows = [
+        _row(cpm=2.0, p95=0.1),
+        _row(cpm=1.0, p95=0.5),
+        _row(cpm=1.0, p95=0.2),  # same cost, lower p95 -> first
+    ]
+    valid, _ = rank(rows)
+    assert [r.cost_per_million for r in valid] == [1.0, 1.0, 2.0]
+    assert valid[0].ttft_p95 == 0.2  # tie broken by lower p95
+
+
+def test_rank_excludes_none_cost_and_zero_ok():
+    rows = [_row(cpm=None), _row(cpm=1.0, ok=0), _row(cpm=2.0)]
+    valid, _ = rank(rows)
+    assert [r.cost_per_million for r in valid] == [2.0]
+
+
+def test_rank_sla_filters_independently_and_combined():
+    rows = [
+        _row(cpm=1.0, p95=0.5, p50=0.3, decode=40),
+        _row(cpm=2.0, p95=0.2, p50=0.1, decode=80),
+    ]
+    _, passing = rank(rows, ttft_p95=0.3)
+    assert [r.cost_per_million for r in passing] == [2.0]
+    _, passing = rank(rows, min_decode=60)
+    assert [r.cost_per_million for r in passing] == [2.0]
+    _, passing = rank(rows, ttft_p50=0.2, ttft_p95=0.3)
+    assert [r.cost_per_million for r in passing] == [2.0]
+    _, passing = rank(rows, ttft_p95=1.0)
+    assert len(passing) == 2  # both pass a loose bar
+
+
+# --------------------------------------------------------------------------- #
+# recommend
+# --------------------------------------------------------------------------- #
+
+
+def test_recommend_cheapest_passing_wins():
+    rows = [_row(cpm=1.0, p95=0.5), _row(cpm=2.0, p95=0.2)]
+    valid, passing = rank(rows, ttft_p95=1.0)
+    rec = recommend(valid, passing, has_bar=True)
+    assert rec.row.cost_per_million == 1.0
+    assert rec.fallback is False
+
+
+def test_recommend_no_bar_global_cheapest_measured():
+    rows = [_row(cpm=3.0), _row(cpm=1.5), _row(cpm=2.0)]
+    valid, passing = rank(rows)
+    rec = recommend(valid, passing, has_bar=False)
+    assert rec.row.cost_per_million == 1.5
+    assert rec.fallback is False
+
+
+def test_recommend_nothing_passing_falls_back_to_lowest_p95():
+    rows = [_row(cpm=1.0, p95=0.9), _row(cpm=2.0, p95=0.5)]
+    valid, passing = rank(rows, ttft_p95=0.1)  # nothing passes
+    assert passing == []
+    rec = recommend(valid, passing, has_bar=True)
+    assert rec.fallback is True
+    assert rec.row.ttft_p95 == 0.5  # lowest p95 measured
+    assert "latency bar" in rec.reason
+
+
+def test_recommend_never_picks_projected_even_when_cheapest():
+    # The cheapest row overall is projected -> must NOT be recommended (Judge-3).
+    proj = _row(cpm=0.1, projected=True, ok=0)
+    measured = _row(cpm=1.0, p95=0.3)
+    # rank() drops the projected row (ok=0) from valid; recommend uses measured.
+    valid, passing = rank([proj, measured])
+    rec = recommend(valid, passing, has_bar=False)
+    assert rec.row is measured
+    assert rec.row.projected is False
+    # Even if a projected row sneaks into the passing list, recommend excludes it.
+    rec2 = recommend([proj, measured], [proj, measured], has_bar=False)
+    assert rec2.row is measured
+
+
+# --------------------------------------------------------------------------- #
+# project_combo
+# --------------------------------------------------------------------------- #
+
+
+class _FakeOption:
+    fits = True
+
+
+class _FakePlan:
+    def __init__(self, fit=True):
+        self._fit = _FakeOption() if fit else None
+        self.weights_gb = 14.0
+
+    @property
+    def cheapest_fit(self):
+        return self._fit
+
+
+class _FakeSizing:
+    def __init__(self, engine="vllm", fit=True):
+        self.engine = engine
+        self._plan = _FakePlan(fit=fit)
+
+    def plan(self, quant):
+        return self._plan
+
+
+class _FakeOffer:
+    def __init__(self, dph):
+        self.dph_total = dph
+
+
+class _FakePriced:
+    def __init__(self, dph):
+        self.offer = _FakeOffer(dph)
+
+
+def test_project_combo_returns_dph():
+    combo = Combo("bf16", [], [], {}, "bf16||")
+    dph = project_combo(
+        combo, repo="org/m", context=None, max_conc=16,
+        size_any=lambda *a, **k: _FakeSizing(),
+        price_plan=lambda plan, disk, max_price=None: [_FakePriced(0.42)],
+        pick_cheapest=lambda priced: priced[0],
+        disk=40, max_price=1.0,
+    )
+    assert dph == 0.42
+
+
+def test_project_combo_no_fit_skips():
+    combo = Combo("bf16", [], [], {}, "bf16||")
+    dph = project_combo(
+        combo, repo="org/m", context=None, max_conc=16,
+        size_any=lambda *a, **k: _FakeSizing(fit=False),
+        price_plan=lambda *a, **k: [],
+        pick_cheapest=lambda p: None,
+        disk=40, max_price=1.0,
+    )
+    assert dph is None
+
+
+def test_project_combo_non_vllm_short_circuits():
+    combo = Combo("Q4_K_M", [], [], {}, "q||")
+    called = {"priced": False}
+
+    def _pp(*a, **k):
+        called["priced"] = True
+        return []
+
+    dph = project_combo(
+        combo, repo="org/m", context=None, max_conc=16,
+        size_any=lambda *a, **k: _FakeSizing(engine="llamacpp"),
+        price_plan=_pp, pick_cheapest=lambda p: None, disk=40, max_price=1.0,
+    )
+    assert dph is None
+    assert called["priced"] is False  # never priced a non-vllm sizing
+
+
+# --------------------------------------------------------------------------- #
+# CostGuard
+# --------------------------------------------------------------------------- #
+
+
+def test_cost_guard_would_exceed_at_launch_boundary():
+    g = CostGuard(max_cost=1.0)
+    assert g.would_exceed(0.5) is False
+    g.add_finished(0.8)
+    assert g.would_exceed(0.5) is True  # 0.8 + 0.5 > 1.0
+
+
+def test_cost_guard_stops_mid_ladder_on_live_cost():
+    g = CostGuard(max_cost=1.0)
+    live = FakeInst(est_cost_so_far=0.4)
+    assert g.check(live_inst=live) is None
+    live.est_cost_so_far = 1.2
+    assert g.check(live_inst=live) == "max-cost"
+
+
+def test_cost_guard_time_exceeded_with_fake_clock():
+    ticks = iter([0.0, 120.0, 600.0])  # init(0), time_exceeded(120), check(600)
+    g = CostGuard(max_minutes=5.0, clock=lambda: next(ticks))
+    assert g.time_exceeded() is False  # 120s = 2 min < 5
+    assert g.check() == "max-minutes"  # 600s = 10 min >= 5
+
+
+# --------------------------------------------------------------------------- #
+# estimate
+# --------------------------------------------------------------------------- #
+
+
+def test_estimate_cost_and_minutes():
+    combos = [Combo("bf16", [], [], {}, "k1"), Combo("fp8", [], [], {}, "k2")]
+    dph = {"k1": 0.60, "k2": 1.20}
+    cost, minutes = estimate(
+        combos, dph, load_minutes_guess=6.0, per_point_minutes=1.0, n_points=4
+    )
+    # each box: 6 + 4 = 10 min. cost = 0.6/60*10 + 1.2/60*10 = 0.1 + 0.2 = 0.3
+    assert minutes == pytest.approx(20.0)
+    assert cost == pytest.approx(0.30)
+
+
+def test_estimate_contingency_widens_load():
+    combos = [Combo("bf16", [], [], {}, "k1")]
+    dph = {"k1": 0.60}
+    base_cost, base_min = estimate(
+        combos, dph, load_minutes_guess=6.0, per_point_minutes=1.0, n_points=0
+    )
+    wide_cost, wide_min = estimate(
+        combos, dph, load_minutes_guess=6.0, per_point_minutes=1.0, n_points=0,
+        cold_pull_contingency=2.0,
+    )
+    assert wide_min == pytest.approx(2 * base_min)
+    assert wide_cost > base_cost
+
+
+def test_estimate_skips_combos_without_projection():
+    combos = [Combo("bf16", [], [], {}, "k1"), Combo("fp8", [], [], {}, "missing")]
+    cost, minutes = estimate(
+        combos, {"k1": 0.6}, load_minutes_guess=6.0, per_point_minutes=1.0, n_points=4
+    )
+    assert minutes == pytest.approx(10.0)  # only k1 counted
+
+
+# --------------------------------------------------------------------------- #
+# run_sweep — teardown invariants (the #1 tests)
+# --------------------------------------------------------------------------- #
+
+
+def _single_combo():
+    return [Combo("bf16", [], [], {}, "bf16||")]
+
+
+def test_run_sweep_success_destroys_once_and_clears_state():
+    st = FakeState()
+
+    def launch(combo):
+        inst = FakeInst()
+        st.save(inst)  # engine.launch saves before returning
+        return inst
+
+    deps, calls = _deps(launch, lambda i, c: FakeBench(), st)
+    plan = SweepPlan(combos=_single_combo(), ladder=[1, 4], guard=CostGuard(max_cost=10))
+    res = run_sweep(deps, plan)
+    assert len(calls["destroy"]) == 1
+    assert st.load() is None
+    assert len([r for r in res.rows if r.ok > 0]) == 2  # two ladder points
+
+
+def test_run_sweep_bench_raises_midladder_still_tears_down():
+    st = FakeState()
+
+    def launch(combo):
+        inst = FakeInst()
+        st.save(inst)
+        return inst
+
+    def bench(inst, c):
+        if c == 4:
+            raise RuntimeError("boom")
+        return FakeBench()
+
+    deps, calls = _deps(launch, bench, st)
+    plan = SweepPlan(combos=_single_combo(), ladder=[1, 4], guard=CostGuard(max_cost=10))
+    res = run_sweep(deps, plan)
+    assert len(calls["destroy"]) == 1
+    assert st.load() is None
+    assert any(r.error == "boom" for r in res.rows)
+
+
+def test_run_sweep_keyboardinterrupt_midladder_tears_down():
+    st = FakeState()
+
+    def launch(combo):
+        inst = FakeInst()
+        st.save(inst)
+        return inst
+
+    def bench(inst, c):
+        raise KeyboardInterrupt
+
+    deps, calls = _deps(launch, bench, st)
+    plan = SweepPlan(combos=_single_combo(), ladder=[1, 4], guard=CostGuard(max_cost=10))
+    res = run_sweep(deps, plan)
+    assert res.interrupted is True
+    assert len(calls["destroy"]) == 1
+    assert st.load() is None
+
+
+def test_run_sweep_launch_returns_none_no_destroy_of_phantom():
+    st = FakeState()
+    deps, calls = _deps(lambda c: None, lambda i, c: FakeBench(), st)
+    plan = SweepPlan(combos=_single_combo(), ladder=[1], guard=CostGuard(max_cost=10))
+    res = run_sweep(deps, plan)
+    # Nothing was rented (state empty) -> no destroy call.
+    assert calls["destroy"] == []
+    assert st.load() is None
+    assert any(r.error for r in res.rows)
+
+
+def test_run_sweep_launch_returns_error_status_tears_down():
+    st = FakeState()
+
+    def launch(combo):
+        inst = FakeInst(status="error")
+        st.save(inst)
+        return inst
+
+    deps, calls = _deps(launch, lambda i, c: FakeBench(), st)
+    plan = SweepPlan(combos=_single_combo(), ladder=[1], guard=CostGuard(max_cost=10))
+    res = run_sweep(deps, plan)
+    assert len(calls["destroy"]) == 1  # the error box is still destroyed
+    assert st.load() is None
+    assert any(r.error for r in res.rows)
+
+
+def test_run_sweep_boot_window_leak_inst_none_destroys_state_load():
+    """Judge-1 fix: Ctrl-C AFTER engine.launch state.save()d the box but BEFORE
+    tune binds `inst` (launch raises KeyboardInterrupt post-save). _teardown must
+    read state.load() and destroy it; final state.load() is None."""
+    st = FakeState()
+
+    def launch(combo):
+        st.save(FakeInst(instance_id=777))  # box rented + saved...
+        raise KeyboardInterrupt  # ...then interrupted before returning
+
+    deps, calls = _deps(launch, lambda i, c: FakeBench(), st)
+    plan = SweepPlan(combos=_single_combo(), ladder=[1], guard=CostGuard(max_cost=10))
+    res = run_sweep(deps, plan)
+    assert res.interrupted is True
+    assert len(calls["destroy"]) == 1
+    assert calls["destroy"][0].instance_id == 777  # destroyed via state.load()
+    assert st.load() is None
+
+
+def test_run_sweep_destroy_failure_still_clears_state():
+    """Belt-and-suspenders: even if destroy() raises (provider error), the state
+    slot must be empty afterward."""
+    st = FakeState()
+
+    def launch(combo):
+        inst = FakeInst()
+        st.save(inst)
+        return inst
+
+    # Custom deps: destroy raises and does NOT clear state.
+    calls = {"destroy": []}
+
+    def _destroy(inst):
+        calls["destroy"].append(inst)
+        raise RuntimeError("provider 500")
+
+    deps = SweepDeps(
+        launch=launch, bench=lambda i, c: FakeBench(), destroy=_destroy,
+        state_load=st.load, state_clear=st.clear,
+    )
+    plan = SweepPlan(combos=_single_combo(), ladder=[1], guard=CostGuard(max_cost=10))
+    run_sweep(deps, plan)
+    assert len(calls["destroy"]) == 1
+    assert st.load() is None  # cleared despite destroy raising
+
+
+# --------------------------------------------------------------------------- #
+# run_sweep — cost cap + early-stop run order
+# --------------------------------------------------------------------------- #
+
+
+def test_run_sweep_cap_breaks_ladder_and_tears_down():
+    st = FakeState()
+    # Each bench point pushes est_cost_so_far past the cap.
+    inst = FakeInst(est_cost_so_far=0.0)
+
+    def launch(combo):
+        st.save(inst)
+        return inst
+
+    def bench(i, c):
+        i.est_cost_so_far += 0.6  # crosses a 1.0 cap after 2 points
+        return FakeBench()
+
+    deps, calls = _deps(launch, bench, st)
+    plan = SweepPlan(combos=_single_combo(), ladder=[1, 4, 8, 16], guard=CostGuard(max_cost=1.0))
+    res = run_sweep(deps, plan)
+    assert res.stop_reason == "max-cost"
+    assert st.load() is None
+    assert len(calls["destroy"]) == 1
+    # Ladder was cut short by the cap (not all 4 points ran).
+    assert len([r for r in res.rows if r.ok > 0]) < 4
+
+
+def test_run_sweep_modeb_stops_launching_next_combo_over_cap():
+    st = FakeState()
+    combos = [Combo("bf16", [], [], {}, "cheap"), Combo("fp8", [], [], {}, "pricey")]
+    launches = {"n": 0}
+
+    def launch(combo):
+        launches["n"] += 1
+        inst = FakeInst(est_cost_so_far=0.9)
+        st.save(inst)
+        return inst
+
+    deps, _ = _deps(launch, lambda i, c: FakeBench(), st)
+    guard = CostGuard(max_cost=1.0)
+    plan = SweepPlan(
+        combos=combos, ladder=[1], guard=guard,
+        projected_dph={"cheap": 0.6, "pricey": 6.0},  # 2nd box est would exceed
+        early_stop=False,
+    )
+    res = run_sweep(deps, plan)
+    # First box runs; the 2nd box's projected cost would blow the cap -> not launched.
+    assert launches["n"] == 1
+    assert res.stop_reason == "max-cost"
+    assert st.load() is None
+
+
+def test_run_sweep_early_stop_skips_dominated_combo():
+    st = FakeState()
+    combos = [Combo("bf16", [], [], {}, "fast"), Combo("fp8", [], [], {}, "slowtier")]
+    launches = []
+
+    def launch(combo):
+        launches.append(combo.key)
+        inst = FakeInst()
+        st.save(inst)
+        return inst
+
+    def bench(i, c):
+        return FakeBench(cost_per_million=1.0, throughput_tok_s=1000.0)
+
+    deps, _ = _deps(launch, bench, st)
+    plan = SweepPlan(
+        combos=combos, ladder=[1], guard=CostGuard(max_cost=100),
+        # 2nd combo's projected floor (dph/3600/best_thrpt) >> incumbent 1.0
+        projected_dph={"fast": 0.3, "slowtier": 100.0}, early_stop=True,
+    )
+    res = run_sweep(deps, plan)
+    assert "fast" in launches
+    assert "slowtier" not in launches  # dominated -> skipped before any rent
+    assert st.load() is None
+    assert res is not None
+
+
+# --------------------------------------------------------------------------- #
+# engine.launch startup_grace (early-abort vs byte-identical default)
+# --------------------------------------------------------------------------- #
+
+
+class _FakeClient:
+    """Never maps a port and never reaches 'running' — a bad node."""
+
+    def __init__(self):
+        self.calls = 0
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *exc):
+        return False
+
+    def price_plan(self, plan, disk, max_price=None):
+        from aiod.vast import PricedOption
+
+        opt = plan.options[0]
+        offer = _FakeVastOffer()
+        return [PricedOption(option=opt, offer=offer)]
+
+    def create_instance(self, *a, **k):
+        return 4242
+
+    def get_instance(self, instance_id):
+        self.calls += 1
+        return {"id": instance_id}
+
+    def endpoint_of(self, vi, port):
+        return None  # never maps
+
+    def status_of(self, vi):
+        return "loading"  # never 'running'
+
+
+@dataclass
+class _FakeVastOffer:
+    id: int = 1
+    dph_total: float = 0.3
+    desc: str = "1x RTX 4090 (24GB)"
+    num_gpus: int = 1
+
+
+def _patch_launch_env(monkeypatch, tmp_path, fake_client):
+    """Wire engine.launch's collaborators to fakes + a tmp state file + fake clock."""
+    from aiod import engine as eng
+    from aiod import state
+
+    monkeypatch.setattr(state, "STATE_FILE", tmp_path / "state.json")
+    monkeypatch.setattr(eng.state, "STATE_FILE", tmp_path / "state.json")
+
+    # Minimal sizing result: one fitting plan/option.
+    from aiod.sizing import GpuOption, GpuTier, ModelSpec, QuantPlan, SizingResult
+
+    tier = GpuTier("RTX 4090", 24, ["RTX 4090"])
+    option = GpuOption(tier=tier, num_gpus=1, total_vram_gb=24, fits=True, headroom_gb=5.0)
+    plan = QuantPlan(
+        quant="bf16", label="bf16", weights_gb=14.0, kv_gb=2.0, required_vram_gb=18.0,
+        options=[option],
+    )
+    spec = ModelSpec(
+        repo_id="org/m", params=7_000_000_000, dtype="BF16", num_layers=32, hidden_size=4096,
+        num_attention_heads=32, num_kv_heads=8, max_context=8192, architecture="llama",
+        gated=False, params_source="safetensors",
+    )
+    sr = SizingResult(model=spec, context_tokens=8192, plans=[plan], engine="vllm")
+    monkeypatch.setattr(eng, "size_model", lambda *a, **k: sr)
+    monkeypatch.setattr(eng.providers, "get_client", lambda provider, s: fake_client)
+    monkeypatch.setattr(eng, "recommend_disk_gb", lambda w: 40)
+    return eng
+
+
+def _settings():
+    from aiod.config import Settings
+
+    return Settings(
+        vast_api_key="k", hf_token=None, vllm_api_key="vk", ttl_hours=4.0, max_price=6.0
+    )
+
+
+def test_engine_launch_startup_grace_aborts_bad_node(monkeypatch, tmp_path):
+    fake = _FakeClient()
+    eng = _patch_launch_env(monkeypatch, tmp_path, fake)
+
+    # Fake clock: jump past the 540s grace quickly.
+    t = {"v": 0.0}
+    monkeypatch.setattr(eng.time, "time", lambda: t["v"])
+
+    def fake_sleep(_s):
+        t["v"] += 600.0  # each loop iteration jumps 600s
+
+    monkeypatch.setattr(eng.time, "sleep", fake_sleep)
+
+    inst = eng.launch(_settings(), model="org/m", quant="bf16", startup_grace=540.0)
+    assert inst is not None
+    assert inst.status == "error"  # aborted early, not after 1200s
+
+
+def test_engine_launch_default_grace_none_does_not_abort_early(monkeypatch, tmp_path):
+    fake = _FakeClient()
+    eng = _patch_launch_env(monkeypatch, tmp_path, fake)
+
+    t = {"v": 0.0}
+    monkeypatch.setattr(eng.time, "time", lambda: t["v"])
+
+    # With grace=None, the only exit is the 1200s while-loop bound. Advance time so
+    # the loop terminates by timeout (NOT by an early abort).
+    def fake_sleep(_s):
+        t["v"] += 700.0
+
+    monkeypatch.setattr(eng.time, "sleep", fake_sleep)
+    # health.wait_until_ready shouldn't be reached (we bail on 'port never mapped'),
+    # but stub it to be safe.
+    monkeypatch.setattr(eng, "wait_until_ready", lambda *a, **k: False)
+
+    inst = eng.launch(_settings(), model="org/m", quant="bf16", startup_grace=None)
+    # Exits via the 1200s bound -> "port never mapped" error path, never the
+    # early-abort branch. The key assertion: get_instance was polled across the
+    # FULL window (more iterations than the grace would have allowed).
+    assert inst is not None
+    assert inst.status == "error"
+    assert fake.calls >= 2  # polled until the 1200s bound, not aborted at grace
+
+
+# --------------------------------------------------------------------------- #
+# --max-cost required (CLI guard)
+# --------------------------------------------------------------------------- #
+
+
+def test_tune_requires_max_cost(monkeypatch, tmp_path):
+    from typer.testing import CliRunner
+
+    from aiod import state
+    from aiod.cli import app
+
+    monkeypatch.setattr(state, "STATE_FILE", tmp_path / "state.json")
+    monkeypatch.setenv("VAST_API_KEY", "k")
+    runner = CliRunner()
+    result = runner.invoke(app, ["tune", "org/m"])
+    assert result.exit_code == 1
+    assert "--max-cost is required" in result.output
+
+
+def test_tune_yes_i_know_escapes_max_cost(monkeypatch, tmp_path):
+    """--yes-i-know lets the command proceed past the max-cost guard (it then
+    fails later for lack of a real provider, but NOT on the cost-gate message)."""
+    from typer.testing import CliRunner
+
+    from aiod import cli, state
+    from aiod.cli import app
+
+    monkeypatch.setattr(state, "STATE_FILE", tmp_path / "state.json")
+    monkeypatch.setenv("VAST_API_KEY", "k")
+
+    # Avoid any network: make sizing/projection fail fast so we reach the
+    # "no rentable combo" exit WITHOUT ever hitting HF/vast.
+    def _boom(*a, **k):
+        raise RuntimeError("no network in tests")
+
+    monkeypatch.setattr(cli, "size_any", _boom)
+    runner = CliRunner()
+    result = runner.invoke(app, ["tune", "org/m", "--yes-i-know", "--dry-run"])
+    # The point: we got PAST the max-cost gate (it's the --yes-i-know escape) and
+    # reached projection (which finds nothing because sizing is stubbed to fail).
+    assert "--max-cost is required" not in result.output
+    assert "No combo has a GPU offer" in result.output
+
+
+# --------------------------------------------------------------------------- #
+# --save-profile round-trip
+# --------------------------------------------------------------------------- #
+
+
+def test_save_tuned_profile_roundtrips_through_opt_tokens(monkeypatch, tmp_path):
+    from aiod import cli, optimizations, profiles
+
+    pf = tmp_path / "profiles.yaml"
+    monkeypatch.setattr(profiles, "PROFILE_FILE", pf)
+
+    winner = _row(cpm=0.5, p95=0.3, conc=8, keys=["max-num-seqs"], quant="fp8")
+    winner.opt_values = {"max-num-seqs": "256"}
+    winner.opt_tokens = ["max-num-seqs=256"]
+
+    cli._save_tuned_profile(
+        "mytune", repo="org/m", provider="vast", winner=winner,
+        context=8192, ttl_h=4.0, idle_m=20, force=False,
+    )
+    saved = profiles.get("mytune")
+    assert saved is not None
+    assert saved.quant == "fp8"
+    assert saved.concurrency == 8
+    assert saved.optimizations == ["max-num-seqs=256"]
+    # Round-trips through the spin resolution path unchanged.
+    tokens = cli._opt_tokens(None, saved)
+    keys, values = optimizations.parse_selection(tokens)
+    assert keys == ["max-num-seqs"]
+    assert values == {"max-num-seqs": "256"}
+
+
+def test_save_tuned_profile_refuses_builtin_without_force(monkeypatch, tmp_path, capsys):
+    from aiod import cli, profiles
+
+    pf = tmp_path / "profiles.yaml"
+    monkeypatch.setattr(profiles, "PROFILE_FILE", pf)
+    winner = _row(cpm=0.5, p95=0.3, conc=4, quant="bf16")
+
+    # 'coder-7b' is a built-in name.
+    cli._save_tuned_profile(
+        "coder-7b", repo="org/m", provider="vast", winner=winner,
+        context=None, ttl_h=None, idle_m=None, force=False,
+    )
+    assert profiles.get("coder-7b").model != "org/m"  # built-in untouched
+    # With force, it writes a user override.
+    cli._save_tuned_profile(
+        "coder-7b", repo="org/m", provider="vast", winner=winner,
+        context=None, ttl_h=None, idle_m=None, force=True,
+    )
+    assert profiles.get("coder-7b").model == "org/m"
+
+
+# --------------------------------------------------------------------------- #
+# Live smoke (skipped without keys)
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.live
+def test_tune_live_smoke():
+    """End-to-end money-safe smoke: rent the cheapest 24GB box, run a tiny sweep,
+    assert a recommendation + that teardown actually happened (state empty).
+    Bounded to sub-$0.20 and a 12-minute cap. Skipped without VAST_API_KEY."""
+    if not os.environ.get("VAST_API_KEY", "").strip():
+        pytest.skip("VAST_API_KEY not set")
+
+    from typer.testing import CliRunner
+
+    from aiod import state
+    from aiod.cli import app
+
+    runner = CliRunner()
+    result = runner.invoke(
+        app,
+        ["tune", "coder-7b", "-c", "1,4", "--n", "2", "--max-cost", "0.20",
+         "--max-minutes", "12", "-y"],
+    )
+    # CRITICAL: the box must be gone regardless of how the sweep ended.
+    assert state.load() is None, "tune must tear down the box (state.load() is None)"
+    # Zero measured rows (slow weight pull) is a skip-with-reason, not a hard fail.
+    if "No measured rows" in result.output:
+        pytest.skip("live node produced no measured rows within the cap")
+    assert result.exit_code == 0


### PR DESCRIPTION
Designed + implemented + adversarially reviewed via multi-agent workflows; **I verified the diff and the cost-safety tests** before pushing.

`aiod tune <model|profile>` rents a box, sweeps it, prints a **$/1M-tokens leaderboard**, and recommends the cheapest serving config that meets a latency bar — the payoff for the v0.4.0 optimization registry.

### Cost-safety is the spine (this rents real GPUs)
- **`--max-cost` is REQUIRED** (or an explicit `--yes-i-know`), enforced before every launch and around every bench point via a `CostGuard`.
- **Teardown is GUARANTEED** on success, exception, AND Ctrl-C — it destroys `inst OR state.load()`, so a box rented during the multi-minute boot is killed even before tune binds the handle.
- Additive **`startup_grace`** kwarg on `engine.launch` (default `None` == today's exact 1200s loop) lets tune early-abort a bad node.

### What it sweeps
- Default: **one box, one model load, a concurrency ladder** (cheap — vLLM batches).
- Opt-combo sweep (relaunch per combo) is **opt-in**.
- Projected (`~`) rows order the run + feed the estimate but are **never the recommendation** — the winner is always a *measured* point.

### Surface
`aiod tune Qwen/Qwen3-32B --max-cost 5 --concurrency 1,4,8 [--sweep-opt kv-cache-fp8] [--save-profile fast]`

### Tests
39 new (teardown-always incl. KeyboardInterrupt + boot-window leak, cost caps, ranking, projected-never-recommended, startup_grace back-compat) + a `@pytest.mark.live` smoke. **205 passing, ruff clean.** Additive only; bumps **v0.5.0**.

### Known nits (follow-ups, no billing leak — box always destroyed)
- Cost cap is between-boundary: a slow weight pull *inside* `engine.launch` can bill past `--max-minutes` before the next check (bounded by the 1800s ready-timeout).
- A rare unexpected-exception-after-rent path skips one box's cost from the running total (cap precision, not a leak).